### PR TITLE
Add basic Rustdoc pattern

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,17 @@
 //
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//!
+//! **Refactor Coaching Platform**
+//! 
+//! A Rust-based backend that provides a web API for various client applications
+//! (e.g. a web frontend) that facilitate the coaching of software engineers.
+//!
+//! The platform itself is useful for professional independent coaches, informal
+//! mentors and engineering leaders who work with individual software engineers
+//! and/or teams by providing a single application that facilitates and enhances
+//! your coaching practice.
+//! 
 
 use service::{config::Config, AppState};
 


### PR DESCRIPTION
## Description

This PR adds the same intro description to the project in Rustdoc format at the top of main.rs. It sets the repository up to be fully ready to use Rustdoc in any of the source files, modules and sub-crates.


#### GitHub Issue: Closes #5 

### Changes
* Add basic Rustdoc pattern to backend source code

### Testing Strategy
`cargo doc --open`

Observe that you see a very basic intro to the project.


### Concerns
N/A
