### PR TITLE
Add two new CLI flags to set the host side TCP interface and port

### DIFF
--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -12,6 +12,14 @@ pub struct Config {
     )]
     pub database_uri: Option<String>,
 
+    /// The host interface to listen for incoming connections
+    #[arg(short, long, default_value = "127.0.0.1")]
+    pub interface: Option<String>,
+
+    /// The host TCP port to listen for incoming connections
+    #[arg(short, long, default_value_t = 4000)]
+    pub port: u16,
+
     /// Turn on different tracing levels [0 = Warn, 1 = Info, 2 = Debug, 3 = Trace]
     #[arg(short, long, default_value_t = 0)]
     pub trace_level: u8,

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -19,7 +19,7 @@ impl OrganizationController {
     /// GET all Organizations
     /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
     /// --request GET \
-    /// http://localhost:3000/organizations
+    /// http://localhost:4000/organizations
     pub async fn index(State(app_state): State<AppState>) -> impl IntoResponse {
         let organizations = organization::Entity::find()
             .all(&app_state.database_connection.unwrap())
@@ -32,7 +32,7 @@ impl OrganizationController {
     /// GET a particular Organization entity specified by its primary key
     /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
     /// --request GET \
-    /// http://localhost:3000/organizations/<id>
+    /// http://localhost:4000/organizations/<id>
     pub async fn read(State(app_state): State<AppState>, Path(id): Path<i32>) -> impl IntoResponse {
         debug!("GET Organization by id: {}", id);
 
@@ -48,7 +48,7 @@ impl OrganizationController {
     /// Test this with curl: curl --header "Content-Type: application/json" \
     /// --request POST \
     /// --data '{"name":"My New Organization"}' \
-    /// http://localhost:3000/organizations
+    /// http://localhost:4000/organizations
     pub async fn create(
         State(app_state): State<AppState>,
         Json(organization_json): Json<organization::Model>,
@@ -71,7 +71,7 @@ impl OrganizationController {
     /// UPDATE a particular Organization entity specified by its primary key
     /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
     /// --request PUT \
-    /// http://localhost:3000/organizations/<id>\?name\=New_Organization_Name
+    /// http://localhost:4000/organizations/<id>\?name\=New_Organization_Name
     pub async fn update(
         State(app_state): State<AppState>,
         Path(id): Path<i32>,
@@ -108,7 +108,7 @@ impl OrganizationController {
     /// DELETE an Organization entity specified by its primary key
     /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
     /// --request DELETE \
-    /// http://localhost:3000/organizations/<id>
+    /// http://localhost:4000/organizations/<id>
     pub async fn delete(
         State(app_state): State<AppState>,
         Path(id): Path<i32>,

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -14,16 +14,16 @@ mod router;
 
 pub async fn init_server(app_state: AppState) -> Result<()> {
     // These will probably come from app_state.config (command line)
-    let host = "127.0.0.1";
-    let port = 3000;
+    let host = app_state.config.interface.as_ref().unwrap();
+    let port = app_state.config.port;
     let server_url = format!("{host}:{port}");
 
-    let addr = SocketAddr::from_str(&server_url).unwrap();
+    let listen_addr = SocketAddr::from_str(&server_url).unwrap();
 
     info!("Server starting... listening for connections on http://{host}:{port}");
 
     // using unwrap() here as the app should panic if the server cannot start
-    Server::bind(&addr)
+    Server::bind(&listen_addr)
         .serve(router::define_routes(app_state).into_make_service())
         .await
         .unwrap();


### PR DESCRIPTION
## Description
This PR adds two new CLI flags to set the host side TCP interface and port to listen on for incoming client connections. Sets the default port to 4000.


#### GitHub Issue: N/A

### Changes
* Adds CLI flag `-i` as `String` to set the host side TCP interface address
* Adds CLI flag `-p` as `u16` to set the host side TCP port

### Testing Strategy
Run the following:
--> `cargo run -- -t 2 -p 3000 -i 127.0.0.1`

and observe that the server outputs an INFO log line showing:
--> `[INFO] Server starting... listening for connections on http://127.0.0.1:3000`


### Concerns
None
