### PR TITLE
Refactor organization2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
  "entity",
  "log",
  "sea-orm",
+ "serde",
  "serde_json",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3373,6 +3373,7 @@ dependencies = [
  "entity_api",
  "log",
  "sea-orm",
+ "serde",
  "serde_json",
  "service",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3370,6 +3370,7 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "entity",
+ "entity_api",
  "log",
  "sea-orm",
  "serde_json",

--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -1,3 +1,6 @@
 pub mod coaching_relationship;
 pub mod organization;
 pub mod user;
+
+/// A type alias that represents any Entity's id field data type
+pub type Id = i32; // TODO: consider changing this to a u64

--- a/entity_api/Cargo.toml
+++ b/entity_api/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 entity = { path = "../entity" }
 serde_json = "1.0.107"
+serde = { version = "1.0", features = ["derive"] }
 log = "0.4.20"
 
 [dependencies.sea-orm]

--- a/entity_api/src/error.rs
+++ b/entity_api/src/error.rs
@@ -1,0 +1,65 @@
+use std::error::Error as StdError;
+use std::fmt;
+
+use sea_orm::error::DbErr;
+
+/// Errors while executing operations related to entities.
+/// The intent is to categorize errors into two major types:
+///  * Errors related to data. Ex DbError::RecordNotFound
+///  * Errors related to interactions with the database itself. Ex DbError::Conn
+#[derive(Debug)]
+pub struct Error {
+    // Underlying error emitted from seaORM internals
+    pub inner: DbErr,
+    // Enum representing which category of error
+    pub error_type: EntityApiErrorType,
+}
+
+#[derive(Debug)]
+pub enum EntityApiErrorType {
+    // Record not found
+    RecordNotFound,
+    // Record not updated
+    RecordNotUpdated,
+    // Errors related to interactions with the database itself. Ex DbError::Conn
+    SystemError,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Entity API Error: {:?}", self)
+    }
+}
+
+impl StdError for Error {}
+
+impl From<DbErr> for Error {
+    fn from(err: DbErr) -> Self {
+        match err {
+            DbErr::RecordNotFound(_) => Error {
+                inner: err,
+                error_type: EntityApiErrorType::RecordNotFound,
+            },
+            DbErr::RecordNotUpdated => Error {
+                inner: err,
+                error_type: EntityApiErrorType::RecordNotUpdated,
+            },
+            DbErr::ConnectionAcquire(_) => Error {
+                inner: err,
+                error_type: EntityApiErrorType::SystemError,
+            },
+            DbErr::Conn(_) => Error {
+                inner: err,
+                error_type: EntityApiErrorType::SystemError,
+            },
+            DbErr::Exec(_) => Error {
+                inner: err,
+                error_type: EntityApiErrorType::SystemError,
+            },
+            _ => Error {
+                inner: err,
+                error_type: EntityApiErrorType::SystemError,
+            },
+        }
+    }
+}

--- a/entity_api/src/error.rs
+++ b/entity_api/src/error.rs
@@ -1,6 +1,8 @@
 use std::error::Error as StdError;
 use std::fmt;
 
+use serde::Serialize;
+
 use sea_orm::error::DbErr;
 
 /// Errors while executing operations related to entities.
@@ -10,12 +12,12 @@ use sea_orm::error::DbErr;
 #[derive(Debug)]
 pub struct Error {
     // Underlying error emitted from seaORM internals
-    pub inner: DbErr,
+    pub inner: Option<DbErr>,
     // Enum representing which category of error
     pub error_type: EntityApiErrorType,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
 pub enum EntityApiErrorType {
     // Record not found
     RecordNotFound,
@@ -37,27 +39,27 @@ impl From<DbErr> for Error {
     fn from(err: DbErr) -> Self {
         match err {
             DbErr::RecordNotFound(_) => Error {
-                inner: err,
+                inner: Some(err),
                 error_type: EntityApiErrorType::RecordNotFound,
             },
             DbErr::RecordNotUpdated => Error {
-                inner: err,
+                inner: Some(err),
                 error_type: EntityApiErrorType::RecordNotUpdated,
             },
             DbErr::ConnectionAcquire(_) => Error {
-                inner: err,
+                inner: Some(err),
                 error_type: EntityApiErrorType::SystemError,
             },
             DbErr::Conn(_) => Error {
-                inner: err,
+                inner: Some(err),
                 error_type: EntityApiErrorType::SystemError,
             },
             DbErr::Exec(_) => Error {
-                inner: err,
+                inner: Some(err),
                 error_type: EntityApiErrorType::SystemError,
             },
             _ => Error {
-                inner: err,
+                inner: Some(err),
                 error_type: EntityApiErrorType::SystemError,
             },
         }

--- a/entity_api/src/error.rs
+++ b/entity_api/src/error.rs
@@ -14,11 +14,11 @@ pub struct Error {
     // Underlying error emitted from seaORM internals
     pub inner: Option<DbErr>,
     // Enum representing which category of error
-    pub error_type: EntityApiErrorType,
+    pub error_code: EntityApiErrorCode,
 }
 
 #[derive(Debug, Serialize)]
-pub enum EntityApiErrorType {
+pub enum EntityApiErrorCode {
     // Record not found
     RecordNotFound,
     // Record not updated
@@ -40,27 +40,27 @@ impl From<DbErr> for Error {
         match err {
             DbErr::RecordNotFound(_) => Error {
                 inner: Some(err),
-                error_type: EntityApiErrorType::RecordNotFound,
+                error_code: EntityApiErrorCode::RecordNotFound,
             },
             DbErr::RecordNotUpdated => Error {
                 inner: Some(err),
-                error_type: EntityApiErrorType::RecordNotUpdated,
+                error_code: EntityApiErrorCode::RecordNotUpdated,
             },
             DbErr::ConnectionAcquire(_) => Error {
                 inner: Some(err),
-                error_type: EntityApiErrorType::SystemError,
+                error_code: EntityApiErrorCode::SystemError,
             },
             DbErr::Conn(_) => Error {
                 inner: Some(err),
-                error_type: EntityApiErrorType::SystemError,
+                error_code: EntityApiErrorCode::SystemError,
             },
             DbErr::Exec(_) => Error {
                 inner: Some(err),
-                error_type: EntityApiErrorType::SystemError,
+                error_code: EntityApiErrorCode::SystemError,
             },
             _ => Error {
                 inner: Some(err),
-                error_type: EntityApiErrorType::SystemError,
+                error_code: EntityApiErrorCode::SystemError,
             },
         }
     }

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -1,5 +1,6 @@
 use sea_orm::DatabaseConnection;
 
+pub mod error;
 pub mod organization;
 
 pub async fn seed_database(db: &DatabaseConnection) {

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -23,7 +23,7 @@ pub async fn create(db: &DatabaseConnection, organization_model: Model) -> Resul
     Ok(organization_active_model.insert(db).await?)
 }
 
-pub async fn update(db: &DatabaseConnection, id: i32, model: Model) -> Result<Model, Error> {
+pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Model, Error> {
     let result = find_by_id(db, id).await?;
 
     match result {

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -70,7 +70,7 @@ pub async fn find_all(db: &DatabaseConnection) -> Result<Vec<Model>, Error> {
     Ok(Entity::find().all(db).await?)
 }
 
-pub async fn find_by_id(db: &DatabaseConnection, id: i32) -> Result<Option<Model>, Error> {
+pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>, Error> {
     let organization = Entity::find_by_id(id).one(db).await?;
     debug!("Organization found: {:?}", organization);
 

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -48,6 +48,8 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: i32) -> Result<(), Error>
 
     match result {
         Some(organization_model) => {
+            debug!("Model to be deleted: {:?}", organization_model);
+
             organization_model.delete(db).await?;
             Ok(())
         }

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -1,5 +1,5 @@
 use super::error::{EntityApiErrorCode, Error};
-use entity::organization;
+use entity::{organization, Id};
 use organization::{ActiveModel, Entity, Model};
 use sea_orm::{
     entity::prelude::*, ActiveValue, ActiveValue::Set, ActiveValue::Unchanged, DatabaseConnection,

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -48,10 +48,7 @@ pub async fn find_all(db: &DatabaseConnection) -> Vec<Model> {
 }
 
 pub async fn find_by_id(db: &DatabaseConnection, id: i32) -> Result<Option<Model>, Error> {
-    Entity::find_by_id(id)
-        .one(db)
-        .await
-        .map_err(|err| err.into())
+    Ok(Entity::find_by_id(id).one(db).await?)
 }
 
 pub(crate) async fn seed_database(db: &DatabaseConnection) {

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -1,15 +1,23 @@
 use super::error::{EntityApiErrorCode, Error};
 use entity::organization;
 use organization::{ActiveModel, Entity, Model};
-use sea_orm::{entity::prelude::*, ActiveValue, DatabaseConnection, TryIntoModel};
+use sea_orm::{
+    entity::prelude::*, ActiveValue, ActiveValue::Set, DatabaseConnection, TryIntoModel,
+};
 use serde_json::json;
 
 extern crate log;
 use log::*;
 
 pub async fn create(db: &DatabaseConnection, organization_model: Model) -> Result<Model, Error> {
-    let organization_active_model: ActiveModel = organization_model.into();
-    debug!("Organization Active Model: {:?}", organization_active_model);
+    let organization_active_model: ActiveModel = ActiveModel {
+        name: Set(organization_model.name.to_owned()),
+        ..Default::default()
+    };
+    debug!(
+        "ActiveModel to be inserted: {:?}",
+        organization_active_model
+    );
 
     Ok(organization_active_model.insert(db).await?)
 }

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -1,4 +1,4 @@
-use super::error::{EntityApiErrorType, Error};
+use super::error::{EntityApiErrorCode, Error};
 use entity::organization;
 use organization::{ActiveModel, Entity, Model};
 use sea_orm::{entity::prelude::*, ActiveValue, DatabaseConnection, TryIntoModel};
@@ -23,7 +23,7 @@ pub async fn update(
         }
         None => Err(Error {
             inner: None,
-            error_type: EntityApiErrorType::RecordNotFound,
+            error_code: EntityApiErrorCode::RecordNotFound,
         }),
     }
 }
@@ -38,7 +38,7 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: i32) -> Result<(), Error>
         }
         None => Err(Error {
             inner: None,
-            error_type: EntityApiErrorType::RecordNotFound,
+            error_code: EntityApiErrorCode::RecordNotFound,
         }),
     }
 }

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -4,8 +4,13 @@ use organization::{ActiveModel, Entity, Model};
 use sea_orm::{entity::prelude::*, ActiveValue, DatabaseConnection, TryIntoModel};
 use serde_json::json;
 
+extern crate log;
+use log::*;
+
 pub async fn create(db: &DatabaseConnection, organization_model: Model) -> Result<Model, Error> {
     let organization_active_model: ActiveModel = organization_model.into();
+    debug!("Organization Active Model: {:?}", organization_active_model);
+
     Ok(organization_active_model.insert(db).await?)
 }
 

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -28,7 +28,7 @@ pub async fn update(db: &DatabaseConnection, id: i32, model: Model) -> Result<Mo
 
     match result {
         Some(organization) => {
-            debug!("Model to be Updated: {:?}", organization);
+            debug!("Existing Organization model to be Updated: {:?}", organization);
 
             let active_model: ActiveModel = ActiveModel {
                 id: Unchanged(organization.id),

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -48,7 +48,7 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: i32) -> Result<(), Error>
 
     match result {
         Some(organization_model) => {
-            debug!("Model to be deleted: {:?}", organization_model);
+            debug!("Existing Organization model to be deleted: {:?}", organization_model);
 
             organization_model.delete(db).await?;
             Ok(())

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -1,10 +1,18 @@
+use super::error::Error;
 use entity::organization;
 use organization::{Entity, Model};
 use sea_orm::{entity::prelude::*, ActiveValue, DatabaseConnection};
 use serde_json::json;
 
 pub async fn find_all(db: &DatabaseConnection) -> Vec<Model> {
-  Entity::find().all(db).await.unwrap_or(vec![])
+    Entity::find().all(db).await.unwrap_or(vec![])
+}
+
+pub async fn find_by_id(db: &DatabaseConnection, id: i32) -> Result<Option<Model>, Error> {
+    match Entity::find_by_id(id).one(db).await {
+        Ok(result) => Ok(result),
+        Err(error) => Err(error.into()),
+    }
 }
 
 pub(crate) async fn seed_database(db: &DatabaseConnection) {

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -1,6 +1,11 @@
 use entity::organization;
+use organization::{Entity, Model};
 use sea_orm::{entity::prelude::*, ActiveValue, DatabaseConnection};
 use serde_json::json;
+
+pub async fn find_all(db: &DatabaseConnection) -> Vec<Model> {
+  Entity::find().all(db).await.unwrap_or(vec![])
+}
 
 pub(crate) async fn seed_database(db: &DatabaseConnection) {
     let organization_names = [

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -16,7 +16,7 @@ pub async fn create(db: &DatabaseConnection, organization_model: Model) -> Resul
         ..Default::default()
     };
     debug!(
-        "ActiveModel to be inserted: {:?}",
+        "New Organization ActiveModel to be inserted: {:?}",
         organization_active_model
     );
 

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -28,7 +28,10 @@ pub async fn update(db: &DatabaseConnection, id: i32, model: Model) -> Result<Mo
 
     match result {
         Some(organization) => {
-            debug!("Existing Organization model to be Updated: {:?}", organization);
+            debug!(
+                "Existing Organization model to be Updated: {:?}",
+                organization
+            );
 
             let active_model: ActiveModel = ActiveModel {
                 id: Unchanged(organization.id),
@@ -48,7 +51,10 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: i32) -> Result<(), Error>
 
     match result {
         Some(organization_model) => {
-            debug!("Existing Organization model to be deleted: {:?}", organization_model);
+            debug!(
+                "Existing Organization model to be deleted: {:?}",
+                organization_model
+            );
 
             organization_model.delete(db).await?;
             Ok(())

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -46,7 +46,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
     }
 }
 
-pub async fn delete_by_id(db: &DatabaseConnection, id: i32) -> Result<(), Error> {
+pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> {
     let result = find_by_id(db, id).await?;
 
     match result {

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -60,12 +60,15 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: i32) -> Result<(), Error>
     }
 }
 
-pub async fn find_all(db: &DatabaseConnection) -> Vec<Model> {
-    Entity::find().all(db).await.unwrap_or(vec![])
+pub async fn find_all(db: &DatabaseConnection) -> Result<Vec<Model>, Error> {
+    Ok(Entity::find().all(db).await?)
 }
 
 pub async fn find_by_id(db: &DatabaseConnection, id: i32) -> Result<Option<Model>, Error> {
-    Ok(Entity::find_by_id(id).one(db).await?)
+    let organization = Entity::find_by_id(id).one(db).await?;
+    debug!("Organization found: {:?}", organization);
+
+    Ok(organization)
 }
 
 pub(crate) async fn seed_database(db: &DatabaseConnection) {

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -9,10 +9,10 @@ pub async fn find_all(db: &DatabaseConnection) -> Vec<Model> {
 }
 
 pub async fn find_by_id(db: &DatabaseConnection, id: i32) -> Result<Option<Model>, Error> {
-    match Entity::find_by_id(id).one(db).await {
-        Ok(result) => Ok(result),
-        Err(error) => Err(error.into()),
-    }
+    Entity::find_by_id(id)
+        .one(db)
+        .await
+        .map_err(|err| err.into())
 }
 
 pub(crate) async fn seed_database(db: &DatabaseConnection) {

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -37,4 +37,8 @@ impl AppState {
             config: app_config,
         }
     }
+
+    pub fn db_conn_ref(&self) -> Option<&DatabaseConnection> {
+        self.database_connection.as_ref()
+    }
 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 entity = { path = "../entity" }
+entity_api = { path = "../entity_api" }
 service = { path = "../service" }
 
 axum = "0.6.20"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -14,6 +14,7 @@ axum = "0.6.20"
 log = "0.4"
 tower-http = { version = "0.4.4", features = ["fs"] }
 serde_json = "1.0.107"
+serde = { version = "1.0", features = ["derive"] }
 
 [dependencies.sea-orm]
 version = "0.12.3" # sea-orm version

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -17,8 +17,7 @@ impl OrganizationController {
     /// --request GET \
     /// http://localhost:4000/organizations
     pub async fn index(State(app_state): State<AppState>) -> impl IntoResponse {
-        let organizations =
-            OrganizationApi::find_all(&app_state.database_connection.unwrap()).await;
+        let organizations = OrganizationApi::find_all(app_state.db_conn_ref().unwrap()).await;
 
         Json(organizations)
     }
@@ -34,7 +33,7 @@ impl OrganizationController {
         debug!("GET Organization by id: {}", id);
 
         let organization: Option<organization::Model> =
-            OrganizationApi::find_by_id(&app_state.database_connection.unwrap(), id).await?;
+            OrganizationApi::find_by_id(app_state.db_conn_ref().unwrap(), id).await?;
 
         Ok(Json(organization))
     }
@@ -51,8 +50,7 @@ impl OrganizationController {
         debug!("CREATE new Organization: {}", organization_model.name);
 
         let organization: organization::Model =
-            OrganizationApi::create(&app_state.database_connection.unwrap(), organization_model)
-                .await?;
+            OrganizationApi::create(app_state.db_conn_ref().unwrap(), organization_model).await?;
 
         Ok(Json(organization))
     }
@@ -71,12 +69,9 @@ impl OrganizationController {
             id, organization_model.name
         );
 
-        let updated_organization: organization::Model = OrganizationApi::update(
-            &app_state.database_connection.unwrap(),
-            id,
-            organization_model,
-        )
-        .await?;
+        let updated_organization: organization::Model =
+            OrganizationApi::update(app_state.db_conn_ref().unwrap(), id, organization_model)
+                .await?;
 
         Ok(Json(updated_organization))
     }
@@ -91,7 +86,7 @@ impl OrganizationController {
     ) -> Result<impl IntoResponse, Error> {
         debug!("DELETE Organization by id: {}", id);
 
-        OrganizationApi::delete_by_id(&app_state.database_connection.unwrap(), id).await?;
+        OrganizationApi::delete_by_id(app_state.db_conn_ref().unwrap(), id).await?;
         Ok(Json(json!({"id": id})))
     }
 }

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -84,7 +84,7 @@ impl OrganizationController {
     /// http://localhost:4000/organizations/<id>
     pub async fn delete(
         State(app_state): State<AppState>,
-        Path(id): Path<i32>,
+        Path(id): Path<Id>,
     ) -> Result<impl IntoResponse, Error> {
         debug!("DELETE Organization by id: {}", id);
 

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -1,5 +1,5 @@
 use crate::{AppState, Error};
-use axum::extract::{Path, Query, State};
+use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use axum::Json;
 use entity::organization;

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -2,7 +2,7 @@ use crate::{AppState, Error};
 use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use axum::Json;
-use entity::organization;
+use entity::{organization, Id};
 use entity_api::organization as OrganizationApi;
 use serde_json::json;
 

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -9,6 +9,7 @@ use sea_orm::ActiveModelTrait;
 use sea_orm::ActiveValue::{NotSet, Set};
 use sea_orm::DeleteResult;
 use serde_json::json;
+use entity_api::organization as OrganizationApi;
 
 extern crate log;
 use log::*;
@@ -21,10 +22,7 @@ impl OrganizationController {
     /// --request GET \
     /// http://localhost:4000/organizations
     pub async fn index(State(app_state): State<AppState>) -> impl IntoResponse {
-        let organizations = organization::Entity::find()
-            .all(&app_state.database_connection.unwrap())
-            .await
-            .unwrap_or(vec![]);
+        let organizations = OrganizationApi::find_all(&app_state.database_connection.unwrap()).await;
 
         Json(organizations)
     }

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -59,12 +59,12 @@ impl OrganizationController {
 
     /// UPDATE a particular Organization entity specified by its primary key
     /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
-    /// --request PUT \
-    /// http://localhost:4000/organizations/<id>\?name\=New_Organization_Name
+    /// --request PUT  http://localhost:4000/organizations/<id> \
+    /// --data '{"name":"My Updated Organization"}'
     pub async fn update(
         State(app_state): State<AppState>,
         Path(id): Path<i32>,
-        Query(organization_model): Query<organization::Model>,
+        Json(organization_model): Json<organization::Model>,
     ) -> Result<impl IntoResponse, Error> {
         debug!(
             "UPDATE the entire Organization by id: {}, new name: {}",

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -16,10 +16,10 @@ impl OrganizationController {
     /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
     /// --request GET \
     /// http://localhost:4000/organizations
-    pub async fn index(State(app_state): State<AppState>) -> impl IntoResponse {
-        let organizations = OrganizationApi::find_all(app_state.db_conn_ref().unwrap()).await;
+    pub async fn index(State(app_state): State<AppState>) -> Result<impl IntoResponse, Error> {
+        let organizations = OrganizationApi::find_all(app_state.db_conn_ref().unwrap()).await?;
 
-        Json(organizations)
+        Ok(Json(organizations))
     }
 
     /// GET a particular Organization entity specified by its primary key

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -63,7 +63,7 @@ impl OrganizationController {
     /// --data '{"name":"My Updated Organization"}'
     pub async fn update(
         State(app_state): State<AppState>,
-        Path(id): Path<i32>,
+        Path(id): Path<Id>,
         Json(organization_model): Json<organization::Model>,
     ) -> Result<impl IntoResponse, Error> {
         debug!(

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -52,6 +52,8 @@ impl OrganizationController {
         let organization: organization::Model =
             OrganizationApi::create(app_state.db_conn_ref().unwrap(), organization_model).await?;
 
+        debug!("Newly Created Organization: {:?}", &organization);
+
         Ok(Json(organization))
     }
 

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -28,7 +28,7 @@ impl OrganizationController {
     /// http://localhost:4000/organizations/<id>
     pub async fn read(
         State(app_state): State<AppState>,
-        Path(id): Path<i32>,
+        Path(id): Path<Id>,
     ) -> Result<impl IntoResponse, Error> {
         debug!("GET Organization by id: {}", id);
 

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -36,10 +36,9 @@ impl OrganizationController {
         debug!("GET Organization by id: {}", id);
 
         let organization: Result<Option<organization::Model>, Error> =
-            match OrganizationApi::find_by_id(&app_state.database_connection.unwrap(), id).await {
-                Ok(result) => Ok(result),
-                Err(error) => Err(error.into()),
-            };
+            OrganizationApi::find_by_id(&app_state.database_connection.unwrap(), id)
+                .await
+                .map_err(|err| err.into());
 
         Json(organization)
     }

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -2,9 +2,8 @@ use std::error::Error as StdError;
 
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
-use serde::Serialize;
 
-use entity_api::error::EntityApiErrorType;
+use entity_api::error::EntityApiErrorCode;
 use entity_api::error::Error as EntityApiError;
 
 pub type Result<T> = core::result::Result<T, Error>;
@@ -20,16 +19,17 @@ impl std::fmt::Display for Error {
     }
 }
 
+// List of possible StatusCode variants https://docs.rs/http/latest/http/status/struct.StatusCode.html#associatedconstant.UNPROCESSABLE_ENTITY
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        match self.0.error_type {
-            EntityApiErrorType::SystemError => {
+        match self.0.error_code {
+            EntityApiErrorCode::SystemError => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
-            EntityApiErrorType::RecordNotFound => {
+            EntityApiErrorCode::RecordNotFound => {
                 (StatusCode::NO_CONTENT, "NO CONTENT").into_response()
             }
-            EntityApiErrorType::RecordNotUpdated => {
+            EntityApiErrorCode::RecordNotUpdated => {
                 (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE ENTITY").into_response()
             }
         }

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -31,7 +31,7 @@ impl IntoResponse for Error {
             Error::InternalServer => {
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
-            Error::EntityNotFound => (StatusCode::NOT_FOUND, "ENTITY NOT FOUND").into_response(),
+            Error::EntityNotFound => (StatusCode::NO_CONTENT, "NO CONTENT").into_response(),
             Error::UnprocessableEntity => {
                 (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE ENTITY").into_response()
             }

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -1,12 +1,28 @@
+use std::error::Error as StdError;
+
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
+use serde::Serialize;
+
+use entity_api::error::EntityApiErrorType;
+use entity_api::error::Error as EntityApiError;
 
 pub type Result<T> = core::result::Result<T, Error>;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize)]
+
 pub enum Error {
     InternalServer,
     EntityNotFound,
+    UnprocessableEntity,
+}
+
+impl StdError for Error {}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> core::result::Result<(), std::fmt::Error> {
+        write!(fmt, "{self:?}")
+    }
 }
 
 impl IntoResponse for Error {
@@ -16,12 +32,19 @@ impl IntoResponse for Error {
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
             Error::EntityNotFound => (StatusCode::NOT_FOUND, "ENTITY NOT FOUND").into_response(),
+            Error::UnprocessableEntity => {
+                (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE ENTITY").into_response()
+            }
         }
     }
 }
 
-impl std::fmt::Display for Error {
-    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> core::result::Result<(), std::fmt::Error> {
-        write!(fmt, "{self:?}")
+impl From<EntityApiError> for Error {
+    fn from(err: EntityApiError) -> Self {
+        match err.error_type {
+            EntityApiErrorType::RecordNotFound => Error::EntityNotFound,
+            EntityApiErrorType::RecordNotUpdated => Error::UnprocessableEntity,
+            EntityApiErrorType::SystemError => Error::InternalServer,
+        }
     }
 }

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -6,6 +6,9 @@ use axum::response::{IntoResponse, Response};
 use entity_api::error::EntityApiErrorCode;
 use entity_api::error::Error as EntityApiError;
 
+extern crate log;
+use log::*;
+
 pub type Result<T> = core::result::Result<T, Error>;
 
 #[derive(Debug)]
@@ -24,12 +27,18 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         match self.0.error_code {
             EntityApiErrorCode::SystemError => {
+                debug!("Error: {:#?}, mapping to INTERNAL_SERVER_ERROR", self);
+
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
             EntityApiErrorCode::RecordNotFound => {
+                debug!("Error: {:#?}, mapping to NO_CONTENT", self);
+
                 (StatusCode::NO_CONTENT, "NO CONTENT").into_response()
             }
             EntityApiErrorCode::RecordNotUpdated => {
+                debug!("Error: {:#?}, mapping to UNPROCESSABLE_ENTITY", self);
+
                 (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE ENTITY").into_response()
             }
         }


### PR DESCRIPTION
## Description
This PR moves seaORM methods and functions for interacting with the database into `entity_api`. It also sets up a basic error handling pattern.


#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_

### Changes
* Move database logic into `entity_api`
* Update `OrganizationController` to invoke `entity_api` functions rather than seaORM functions
* Begin formalizing error handling pattern

