### PR TITLE
Add permissive Cors policy in response headers

### DIFF
--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -13,7 +13,7 @@ service = { path = "../service" }
 axum = "0.7.2"
 axum-login = "0.12.0"
 log = "0.4"
-tower-http = { version = "0.5.0", features = ["fs"] }
+tower-http = { version = "0.5.0", features = ["fs", "cors"] }
 serde_json = "1.0.107"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1.35.0", features = ["full"] }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -10,6 +10,7 @@ use service::AppState;
 use std::net::SocketAddr;
 use std::str::FromStr;
 use time::Duration;
+use tower_http::cors::CorsLayer;
 use tokio::net::TcpListener;
 
 mod controller;
@@ -57,6 +58,7 @@ pub async fn init_server(app_state: AppState) -> Result<()> {
     axum::serve(
         listener,
         router::define_routes(app_state)
+            .layer(CorsLayer::permissive()) // FIXME: permissive for early development convenience
             .layer(auth_layer)
             .into_make_service(),
     )


### PR DESCRIPTION
## Description
This PR adds permissive Cors policy in response headers for development convenience. Will need to make this more precise in the future before production deployment.

This was meant to be in the last PR but didn't get pushed up in time before merging.


#### GitHub Issue: N/A

### Changes
* Add permissive Cors policy in response headers

### Testing Strategy
Test with the [related frontend branch adding login functionality](https://github.com/Jim-Hodapp-Coaching/refactor-platform-fe/pull/10), if you're able to login then the Cors policy is working as expected.


### Concerns
This is a permissive policy meant to be tweaked and tightened before ANY public deployments onto the internet.
