### PR TITLE
Tweak CORS policy for origin http://localhost:3000

### DIFF
--- a/web/src/controller/user_session_controller.rs
+++ b/web/src/controller/user_session_controller.rs
@@ -58,17 +58,12 @@ impl UserSessionController {
             return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
         }
 
-        if let Some(ref next) = creds.next {
-            debug!("Redirecting to next: {next}");
-            Ok(Redirect::to(next).into_response())
-        } else {
-            let response_json = Json(
-                json!({"first_name": user.first_name, "last_name": user.last_name, 
-                    "email": user.email, "display_name": user.display_name}),
-            );
-            debug!("JSON response with 200 OK: {:?}", response_json);
-            Ok(response_json.into_response())
-        }
+        let response_json = Json(
+            json!({"first_name": user.first_name, "last_name": user.last_name, 
+                "email": user.email, "display_name": user.display_name}),
+        );
+        debug!("JSON response with 200 OK: {:?}", response_json);
+        Ok(response_json.into_response())
     }
 
     /// Logs the user out of the platform by destroying their session.
@@ -76,6 +71,7 @@ impl UserSessionController {
     /// --header "Cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df" \
     /// --request GET http://localhost:4000/logout
     pub async fn logout(mut auth_session: UserApi::AuthSession) -> impl IntoResponse {
+        debug!("UserSessionController::logout()");
         match auth_session.logout().await {
             Ok(_) => Redirect::to("/login").into_response(),
             Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -35,13 +35,12 @@ pub fn organization_routes(app_state: AppState) -> Router {
 pub fn protected_routes() -> Router {
     Router::new()
         .route("/protected", get(UserSessionController::protected))
+        .route("/logout", get(UserSessionController::logout))
         .route_layer(login_required!(Backend, login_url = "/login"))
 }
 
 pub fn session_routes() -> Router {
-    Router::new()
-        .route("/login", post(UserSessionController::login))
-        .route("/logout", get(UserSessionController::logout))
+    Router::new().route("/login", post(UserSessionController::login))
 }
 
 // This will serve static files that we can use as a "fallback" for when the server panics


### PR DESCRIPTION
## Description
This PR tweaks the CORS policy for http://localhost:3000 to allow for trusted credentials auth cookies (HttpOnly) to be set/unset from server-->client. This gets rid of the wildcard policy which is worthless (rightfully so) for the trusted exchange of credential information across origins (i.e. http://localhost:3000 --> http://localhost:4000).

The client knows to use this id for all subsequent API calls to the backend until the session is unset and destroyed by the backend.


#### GitHub Issue: None

### Changes
* Adds proper `allow-credentials` and `allow-origin` policies for http://localhost:3000 for HTTP operations: DELETE, GET, POST, PUT, PATCH

### Testing Strategy
* Log in using the front end and notice that a local auth session cookie is set in the browser


### Concerns
None
