### PR TITLE
No need to redirect a client after successful logout

### DIFF
--- a/web/src/controller/user_session_controller.rs
+++ b/web/src/controller/user_session_controller.rs
@@ -1,8 +1,4 @@
-use axum::{
-    http::StatusCode,
-    response::{IntoResponse, Redirect},
-    Form, Json,
-};
+use axum::{http::StatusCode, response::IntoResponse, Form, Json};
 use entity_api::user as UserApi;
 use log::*;
 use serde::Deserialize;
@@ -73,7 +69,7 @@ impl UserSessionController {
     pub async fn logout(mut auth_session: UserApi::AuthSession) -> impl IntoResponse {
         debug!("UserSessionController::logout()");
         match auth_session.logout().await {
-            Ok(_) => Redirect::to("/login").into_response(),
+            Ok(_) => StatusCode::OK.into_response(),
             Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
         }
     }


### PR DESCRIPTION
## Description
No need to redirect a client after successful logout, return 200 OK instead.


#### GitHub Issue: None

### Changes
* Return 200 OK after successful logout instead of redirecting

### Testing Strategy
Use the client frontend, login, then select logout from the menu in the upper right hand corner.


### Concerns
None
