### PR TITLE
Fix all router endpoint integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -706,6 +706,17 @@ checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "cookie"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd91cf61412820176e137621345ee43b3f4423e589e7ae4e50d601d93e35ef8"
@@ -713,6 +724,23 @@ dependencies = [
  "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d606d0fba62e13cf04db20536c05cb7f13673c161cb47a47a82b9b9e7d3f1daa"
+dependencies = [
+ "cookie 0.16.2",
+ "idna 0.2.3",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1458,6 +1486,27 @@ dependencies = [
 
 [[package]]
 name = "idna"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+dependencies = [
+ "matches",
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "idna"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
@@ -1618,6 +1667,12 @@ checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
  "regex-automata 0.1.10",
 ]
+
+[[package]]
+name = "matches"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2532096657941c2fea9c289d370a250971c689d4f143798ff67113ec042024a5"
 
 [[package]]
 name = "matchit"
@@ -2134,6 +2189,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,6 +2212,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96a8c1bda5ae1af7f99a2962e49df150414a43d62404644d98dd5c3a93d07457"
+dependencies = [
+ "idna 0.3.0",
+ "psl-types",
 ]
 
 [[package]]
@@ -2281,6 +2352,8 @@ checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
 dependencies = [
  "base64",
  "bytes",
+ "cookie 0.16.2",
+ "cookie_store",
  "encoding_rs",
  "futures-core",
  "futures-util",
@@ -3432,7 +3505,7 @@ checksum = "4fd0118512cf0b3768f7fcccf0bef1ae41d68f2b45edc1e77432b36c97c56c6d"
 dependencies = [
  "async-trait",
  "axum-core",
- "cookie",
+ "cookie 0.18.0",
  "futures-util",
  "http 1.0.0",
  "parking_lot",
@@ -3652,7 +3725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
- "idna",
+ "idna 0.5.0",
  "percent-encoding",
 ]
 
@@ -3790,9 +3863,11 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-login",
+ "chrono",
  "entity",
  "entity_api",
  "log",
+ "password-auth",
  "reqwest",
  "sea-orm",
  "serde",

--- a/entity_api/src/user.rs
+++ b/entity_api/src/user.rs
@@ -20,10 +20,12 @@ pub struct Credentials {
 }
 
 impl Backend {
-    pub fn new(db: &DatabaseConnection) -> Self {
+    pub fn new(db: &Arc<DatabaseConnection>) -> Self {
         info!("** Backend::new()");
         Self {
-            db: Arc::new(db.clone()),
+            // Arc is cloned, but the inner DatabaseConnection refers to the same instance
+            // as the one passed in to new() (see the Arc documentation for more info)
+            db: Arc::clone(db),
         }
     }
 }

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -31,9 +31,9 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(app_config: Config, db: DatabaseConnection) -> Self {
+    pub fn new(app_config: Config, db: &Arc<DatabaseConnection>) -> Self {
         Self {
-            database_connection: Arc::new(db),
+            database_connection: Arc::clone(db),
             config: app_config,
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@
 
 use log::*;
 use service::{config::Config, logging::Logger, AppState};
+use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
@@ -33,9 +34,9 @@ async fn main() {
 
     info!("Starting up...");
 
-    let db = service::init_database(config.database_uri()).await.unwrap();
+    let db = Arc::new(service::init_database(config.database_uri()).await.unwrap());
 
-    let app_state = AppState::new(config, db);
+    let app_state = AppState::new(config, &db);
 
     entity_api::seed_database(app_state.db_conn_ref()).await;
 

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -36,4 +36,6 @@ mock = ["sea-orm/mock"]
 
 [dev-dependencies]
 anyhow = "1.0.76"
-reqwest = { version = "0.11.23", features = ["json"] }
+chrono = { version = "0.4.34", features = ["serde"] }
+password-auth = "1.0.0"
+reqwest = { version = "0.11.23", features = ["json", "cookies"] }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -44,7 +44,7 @@ pub async fn init_server(app_state: AppState) -> Result<()> {
         .with_expiry(Expiry::OnInactivity(Duration::days(1)));
 
     // Auth service
-    let backend = Backend::new(app_state.db_conn_ref());
+    let backend = Backend::new(&app_state.database_connection);
     let auth_layer = AuthManagerLayerBuilder::new(backend, session_layer).build();
 
     // These will probably come from app_state.config (command line)

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -55,6 +55,7 @@ pub fn static_routes() -> Router {
 #[cfg(feature = "mock")]
 mod organization_endpoints_tests {
     use super::*;
+    use anyhow::Ok;
     use axum_login::{
         tower_sessions::{Expiry, MemoryStore, SessionManagerLayer},
         AuthManagerLayerBuilder,
@@ -75,7 +76,7 @@ mod organization_endpoints_tests {
 
     // Enable and call this at the start of a particular test to turn on TRACE
     // level logging output used to debug a new or existing test.
-    fn enable_test_logging(config: &mut Config) {
+    fn _enable_test_logging(config: &mut Config) {
         config.log_level_filter = LevelFilter::Trace;
         Logger::init_logger(&config);
     }
@@ -124,71 +125,84 @@ mod organization_endpoints_tests {
             let url = base.join(path.as_ref())?;
             Ok(url.as_str().to_string())
         }
+
+        /// Logs into a new AuthSession with a session cookie. The cookie will be
+        /// cached by the client Reqwest instance because we constructed the client
+        /// with it turned on (i.e. `cookie_store(true)`).
+        ///
+        /// This is meant to be reused by all tests that sit behind a protected route.
+        pub async fn login(&mut self, user: &user::Model) -> anyhow::Result<()> {
+            let creds = [("email", "test@domain.com"), ("password", "password2")];
+            let response = self
+                .client
+                .post(self.url("/login").unwrap())
+                .form(&creds)
+                .send()
+                .await?;
+
+            let response_text = response.text().await?;
+            debug!("response_text: {:?}", response_text);
+            assert_eq!(
+                response_text,
+                json!({
+                    "display_name": user.display_name,
+                    "email": user.email,
+                    "first_name": user.first_name,
+                    "last_name": user.last_name,
+                })
+                .to_string()
+            );
+
+            Ok(())
+        }
+
+        /// Creates a test user::Model entity instance that can be used by tests to
+        /// log in to the /login endpoint and create a valid AuthSession.
+        pub fn get_user() -> anyhow::Result<user::Model> {
+            let now = Utc::now();
+            Ok(user::Model {
+                id: 1,
+                email: "test@domain.com".to_string(),
+                first_name: "".to_string(),
+                last_name: "".to_string(),
+                display_name: "".to_string(),
+                password: generate_hash("password2").to_owned(),
+                github_username: "".to_string(),
+                github_profile_url: "".to_string(),
+                created_at: now,
+                updated_at: now,
+            })
+        }
     }
 
     // Purpose: adds an Organization instance to a mock DB and tests the API to successfully
     // retrieve it by a specific ID and as expected and valid JSON.
     #[tokio::test]
     async fn read_returns_expected_json_for_specified_organization() -> anyhow::Result<()> {
-        let now = Utc::now();
-        let user_results1 = [vec![user::Model {
-            id: 1,
-            email: "test@domain.com".to_string(),
-            first_name: "".to_string(),
-            last_name: "".to_string(),
-            display_name: "".to_string(),
-            password: generate_hash("password2").to_owned(),
-            github_username: "".to_string(),
-            github_profile_url: "".to_string(),
-            created_at: now,
-            updated_at: now,
-        }]];
+        let user = TestClientServer::get_user().expect("Creating a new test user failed");
+        let user_results1 = [vec![user.clone()]];
 
         let organization_results = [vec![organization::Model {
             id: 1,
             name: "Organization One".to_owned(),
         }]];
 
-        let mut config = Config::default();
-        enable_test_logging(&mut config);
-
         let db = Arc::new(
             MockDatabase::new(DatabaseBackend::Postgres)
                 .append_query_results(user_results1.clone())
-                // The user used in the axum-login AuthSession has to be identical and unique, otherwise
-                // it'll fail to verify the session when calling other protected endpoints
                 .append_query_results(user_results1.clone())
                 .append_query_results(organization_results.clone())
                 .into_connection(),
         );
 
-        let app_state = AppState::new(config, &db);
+        let app_state = AppState::new(Config::default(), &db);
 
-        let test_client_server = TestClientServer::new(define_routes(app_state), &db)
+        let mut test_client_server = TestClientServer::new(define_routes(app_state), &db)
             .await
             .unwrap();
 
-        let creds = [("email", "test@domain.com"), ("password", "password2")];
-        let response = test_client_server
-            .client
-            .post(test_client_server.url("/login").unwrap())
-            .form(&creds)
-            .send()
-            .await?;
-
-        let response_text = response.text().await?;
-        debug!("response_text: {:?}", response_text);
-        let user_model = &user_results1[0][0];
-        assert_eq!(
-            response_text,
-            json!({
-                "display_name": user_model.display_name,
-                "email": user_model.email,
-                "first_name": user_model.first_name,
-                "last_name": user_model.last_name,
-            })
-            .to_string()
-        );
+        let response = test_client_server.login(&user).await?;
+        assert_eq!(response, ()); // Make sure we get a 200 OK response
 
         let response = test_client_server
             .client
@@ -197,10 +211,9 @@ mod organization_endpoints_tests {
             .await?;
 
         let response_text = response.text().await?;
-        debug!("response_text: {:?}", response_text);
 
-        let organization_model1 = &organization_results[0][0];
-        assert_eq!(response_text, json!(organization_model1).to_string());
+        let organization1 = &organization_results[0][0];
+        assert_eq!(response_text, json!(organization1).to_string());
 
         Ok(())
     }
@@ -209,6 +222,9 @@ mod organization_endpoints_tests {
     // retrieve all of them as expected and valid JSON without specifying any particular ID.
     #[tokio::test]
     async fn read_returns_all_organizations() -> anyhow::Result<()> {
+        let user = TestClientServer::get_user().expect("Creating a new test user failed");
+        let user_results1 = [vec![user.clone()]];
+
         // Note: for entity_api::organization::find_all() to be able to return
         // the correct query_results for the assert_eq!() below, they must all
         // be grouped together in the same inner vector.
@@ -229,15 +245,20 @@ mod organization_endpoints_tests {
 
         let db = Arc::new(
             MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(user_results1.clone())
+                .append_query_results(user_results1.clone())
                 .append_query_results(organizations.clone())
                 .into_connection(),
         );
 
         let app_state = AppState::new(Config::default(), &db);
 
-        let test_client_server = TestClientServer::new(define_routes(app_state), &db)
+        let mut test_client_server = TestClientServer::new(define_routes(app_state), &db)
             .await
             .unwrap();
+
+        let response = test_client_server.login(&user).await?;
+        assert_eq!(response, ());
 
         let response = test_client_server
             .client
@@ -247,18 +268,13 @@ mod organization_endpoints_tests {
             .text()
             .await?;
 
-        let organization_model1 = &organizations[0][0];
-        let organization_model2 = &organizations[0][1];
-        let organization_model3 = &organizations[0][2];
+        let organization1 = &organizations[0][0];
+        let organization2 = &organizations[0][1];
+        let organization3 = &organizations[0][2];
 
         assert_eq!(
             response,
-            json!([
-                organization_model1,
-                organization_model2,
-                organization_model3
-            ])
-            .to_string()
+            json!([organization1, organization2, organization3]).to_string()
         );
 
         Ok(())
@@ -268,40 +284,49 @@ mod organization_endpoints_tests {
     // the appropriate endpoint deletes instances specified by distinct IDs.
     #[tokio::test]
     async fn delete_an_organization_specified_by_id() -> anyhow::Result<()> {
-        let organizations = [
-            vec![organization::Model {
-                id: 2,
-                name: "Organization Two".to_owned(),
-            }],
-            vec![organization::Model {
-                id: 3,
-                name: "Organization Three".to_owned(),
-            }],
-        ];
+        let user = TestClientServer::get_user().expect("Creating a new test user failed");
+        let user_results1 = [vec![user.clone()]];
 
-        let exec_results = [
-            MockExecResult {
-                last_insert_id: 2,
-                rows_affected: 1,
-            },
-            MockExecResult {
-                last_insert_id: 3,
-                rows_affected: 1,
-            },
-        ];
+        let organization_results1 = [vec![organization::Model {
+            id: 2,
+            name: "Organization Two".to_owned(),
+        }]];
+        let organization_results2 = [vec![organization::Model {
+            id: 3,
+            name: "Organization Three".to_owned(),
+        }]];
+
+        let exec_results1 = [MockExecResult {
+            last_insert_id: 2,
+            rows_affected: 1,
+        }];
+
+        let exec_results2 = [MockExecResult {
+            last_insert_id: 3,
+            rows_affected: 1,
+        }];
 
         let db = Arc::new(
             MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results(organizations.clone())
-                .append_exec_results(exec_results)
+                .append_query_results(user_results1.clone()) // For the initial login auth check
+                .append_query_results(user_results1.clone()) // For the AuthSession check done with the next endpoint call
+                .append_query_results(organization_results1.clone()) // For comparing the first organization query results with
+                .append_exec_results(exec_results1) // For comparing the first organization query execution results with
+                .append_query_results(user_results1.clone()) // For the AuthSession check done with the next endpoint call
+                .append_query_results(organization_results1.clone()) // For compare the second organization query results with
+                .append_exec_results(exec_results2) // For comparing the second organization query execution results with
                 .into_connection(),
         );
 
         let app_state = AppState::new(Config::default(), &db);
 
-        let test_client_server = TestClientServer::new(define_routes(app_state), &db)
+        let mut test_client_server = TestClientServer::new(define_routes(app_state), &db)
             .await
             .unwrap();
+
+        let response = test_client_server.login(&user).await?;
+        assert_eq!(response, ());
+
         {
             let response = test_client_server
                 .client
@@ -311,12 +336,12 @@ mod organization_endpoints_tests {
                 .text()
                 .await?;
 
-            let organization_model2 = &organizations[0][0];
+            let organization2 = &organization_results1[0][0];
 
             assert_eq!(
                 response,
                 json!({
-                    "id": organization_model2.id,
+                    "id": organization2.id,
                 })
                 .to_string()
             );
@@ -331,12 +356,12 @@ mod organization_endpoints_tests {
                 .text()
                 .await?;
 
-            let organization_model3 = &organizations[1][0];
+            let organization3 = &organization_results2[0][0];
 
             assert_eq!(
                 response,
                 json!({
-                    "id": organization_model3.id,
+                    "id": organization3.id,
                 })
                 .to_string()
             );
@@ -349,68 +374,78 @@ mod organization_endpoints_tests {
     // the post endpoint supplying the appropriate instance as a JSON payload.
     #[tokio::test]
     async fn create_new_organizations_successfully() -> anyhow::Result<()> {
-        let organizations = [
-            vec![organization::Model {
-                id: 5,
-                name: "New Organization Five".to_owned(),
-            }],
-            vec![organization::Model {
-                id: 6,
-                name: "Second Organization Six".to_owned(),
-            }],
-        ];
+        let user = TestClientServer::get_user().expect("Creating a new test user failed");
+        let user_results1 = [vec![user.clone()]];
 
-        let exec_results = [
-            MockExecResult {
-                last_insert_id: 5,
-                rows_affected: 1,
-            },
-            MockExecResult {
-                last_insert_id: 6,
-                rows_affected: 1,
-            },
-        ];
+        let organization_results1 = [vec![organization::Model {
+            id: 5,
+            name: "New Organization Five".to_owned(),
+        }]];
+
+        let organization_results2 = [vec![organization::Model {
+            id: 6,
+            name: "Second Organization Six".to_owned(),
+        }]];
+
+        let exec_results1 = [MockExecResult {
+            last_insert_id: 5,
+            rows_affected: 1,
+        }];
+
+        let exec_results2 = [MockExecResult {
+            last_insert_id: 6,
+            rows_affected: 1,
+        }];
 
         let db = Arc::new(
             MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results(organizations.clone())
-                .append_exec_results(exec_results)
+                .append_query_results(user_results1.clone())
+                .append_query_results(user_results1.clone())
+                .append_query_results(organization_results1.clone())
+                .append_exec_results(exec_results1)
+                .append_query_results(user_results1.clone())
+                .append_query_results(organization_results2.clone())
+                .append_exec_results(exec_results2)
                 .into_connection(),
         );
 
         let app_state = AppState::new(Config::default(), &db);
 
-        let test_client_server = TestClientServer::new(define_routes(app_state), &db)
+        let mut test_client_server = TestClientServer::new(define_routes(app_state), &db)
             .await
             .unwrap();
+
+        let response = test_client_server.login(&user).await?;
+        assert_eq!(response, ());
+
         {
-            let organization_model5 = &organizations[0][0];
+            let organization5 = &organization_results1[0][0];
 
             let response = test_client_server
                 .client
                 .post(test_client_server.url("/organizations").unwrap())
-                .json(&organization_model5)
+                .json(&organization5)
                 .send()
                 .await?
                 .text()
                 .await?;
 
-            assert_eq!(response, json!(organization_model5).to_string());
+            assert_eq!(response, json!(organization5).to_string());
         }
 
         {
-            let organization_model6 = &organizations[1][0];
+            let organization6 = &organization_results2[0][0];
 
             let response = test_client_server
                 .client
                 .post(test_client_server.url("/organizations").unwrap())
-                .json(&organization_model6)
+                .json(&organization6)
                 .send()
                 .await?
                 .text()
                 .await?;
 
-            assert_eq!(response, json!(organization_model6).to_string());
+            assert_eq!(response, json!(organization6).to_string());
         }
 
         Ok(())
@@ -420,6 +455,9 @@ mod organization_endpoints_tests {
     // the appropriate endpoint updates an instance specified by an ID.
     #[tokio::test]
     async fn update_an_organization_specified_by_id() -> anyhow::Result<()> {
+        let user = TestClientServer::get_user().expect("Creating a new test user failed");
+        let user_results1 = [vec![user.clone()]];
+
         let organizations = [
             vec![organization::Model {
                 id: 2,
@@ -438,6 +476,8 @@ mod organization_endpoints_tests {
 
         let db = Arc::new(
             MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(user_results1.clone())
+                .append_query_results(user_results1.clone())
                 .append_query_results(organizations.clone())
                 .append_exec_results(exec_results)
                 .into_connection(),
@@ -445,11 +485,14 @@ mod organization_endpoints_tests {
 
         let app_state = AppState::new(Config::default(), &db);
 
-        let test_client_server = TestClientServer::new(define_routes(app_state), &db)
+        let mut test_client_server = TestClientServer::new(define_routes(app_state), &db)
             .await
             .unwrap();
 
-        let updated_organization_model2 = organization::Model {
+        let response = test_client_server.login(&user).await?;
+        assert_eq!(response, ());
+
+        let updated_organization2 = organization::Model {
             id: 2,
             name: "Updated Organization Two".to_owned(),
         };
@@ -457,13 +500,13 @@ mod organization_endpoints_tests {
         let response = test_client_server
             .client
             .put(test_client_server.url("/organizations/2").unwrap())
-            .json(&updated_organization_model2)
+            .json(&updated_organization2)
             .send()
             .await?
             .text()
             .await?;
 
-        assert_eq!(response, json!(updated_organization_model2).to_string());
+        assert_eq!(response, json!(updated_organization2).to_string());
 
         Ok(())
     }


### PR DESCRIPTION
## Description
This PR fixes all of the broken tests in router.rs that broke when we introduced AuthSession from axum-login and the Organization endpoints being protected behind a valid login session.

#### GitHub Issue: Fixes #32 

### Changes
* Update all tests to log in and establish a valid AuthSession

### Testing Strategy
1. Run `cargo test` and ensure all tests pass


### Concerns
None
