### PR TITLE
Add a custom Extractor to check for a valid API version in client request header

### DIFF
--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -2,9 +2,22 @@ use clap::builder::TypedValueParser as _;
 use clap::Parser;
 use log::LevelFilter;
 
+pub const DEFAULT_API_VERSION: &str = "0.0.1";
+// Expand this array to include all valid API versions. Versions that have been
+// completely removed should be removed from this list - they're no longer valid.
+pub const API_VERSIONS: [&str; 1] = [DEFAULT_API_VERSION];
+
 #[derive(Clone, Debug, Parser)]
 #[command(author, version, about, long_about = None)]
 pub struct Config {
+    /// Set the current semantic version of the endpoint API to expose to clients. All
+    /// endpoints not contained in the specified version will not be exposed by the router.
+    #[arg(short, long, env, default_value = DEFAULT_API_VERSION,
+        value_parser = clap::builder::PossibleValuesParser::new(API_VERSIONS)
+            .map(|s| s.parse::<String>().unwrap()),
+        )]
+    pub api_version: Option<String>,
+
     /// Sets the Postgresql database URI to connect to
     #[arg(
         short,

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -57,6 +57,12 @@ impl Config {
         Config::parse()
     }
 
+    pub fn api_version(&self) -> &str {
+        self.api_version
+            .as_ref()
+            .expect("No API version string provided")
+    }
+
     pub fn set_database_uri(mut self, database_uri: String) -> Self {
         self.database_uri = Some(database_uri);
         self

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -1,4 +1,4 @@
-use crate::{AppState, Error};
+use crate::{custom_extractors::CheckApiVersion, AppState, Error};
 use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use axum::Json;
@@ -15,7 +15,10 @@ impl OrganizationController {
     /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
     /// --request GET \
     /// http://localhost:4000/organizations
-    pub async fn index(State(app_state): State<AppState>) -> Result<impl IntoResponse, Error> {
+    pub async fn index(
+        CheckApiVersion(_v): CheckApiVersion,
+        State(app_state): State<AppState>,
+    ) -> Result<impl IntoResponse, Error> {
         debug!("GET all Organizations");
         let organizations = OrganizationApi::find_all(app_state.db_conn_ref()).await?;
 
@@ -29,6 +32,7 @@ impl OrganizationController {
     /// --request GET \
     /// http://localhost:4000/organizations/<id>
     pub async fn read(
+        CheckApiVersion(_v): CheckApiVersion,
         State(app_state): State<AppState>,
         Path(id): Path<Id>,
     ) -> Result<impl IntoResponse, Error> {
@@ -46,6 +50,7 @@ impl OrganizationController {
     /// --data '{"name":"My New Organization"}' \
     /// http://localhost:4000/organizations
     pub async fn create(
+        CheckApiVersion(_v): CheckApiVersion,
         State(app_state): State<AppState>,
         Json(organization_model): Json<organizations::Model>,
     ) -> Result<impl IntoResponse, Error> {
@@ -64,6 +69,7 @@ impl OrganizationController {
     /// --request PUT  http://localhost:4000/organizations/<id> \
     /// --data '{"name":"My Updated Organization"}'
     pub async fn update(
+        CheckApiVersion(_v): CheckApiVersion,
         State(app_state): State<AppState>,
         Path(id): Path<Id>,
         Json(organization_model): Json<organizations::Model>,
@@ -84,6 +90,7 @@ impl OrganizationController {
     /// --request DELETE \
     /// http://localhost:4000/organizations/<id>
     pub async fn delete(
+        CheckApiVersion(_v): CheckApiVersion,
         State(app_state): State<AppState>,
         Path(id): Path<Id>,
     ) -> Result<impl IntoResponse, Error> {

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -1,4 +1,4 @@
-use crate::{custom_extractors::CheckApiVersion, AppState, Error};
+use crate::{custom_extractors::CompareApiVersion, AppState, Error};
 use axum::extract::{Path, State};
 use axum::response::IntoResponse;
 use axum::Json;
@@ -16,7 +16,7 @@ impl OrganizationController {
     /// --request GET \
     /// http://localhost:4000/organizations
     pub async fn index(
-        CheckApiVersion(_v): CheckApiVersion,
+        CompareApiVersion(_v): CompareApiVersion,
         State(app_state): State<AppState>,
     ) -> Result<impl IntoResponse, Error> {
         debug!("GET all Organizations");
@@ -32,7 +32,7 @@ impl OrganizationController {
     /// --request GET \
     /// http://localhost:4000/organizations/<id>
     pub async fn read(
-        CheckApiVersion(_v): CheckApiVersion,
+        CompareApiVersion(_v): CompareApiVersion,
         State(app_state): State<AppState>,
         Path(id): Path<Id>,
     ) -> Result<impl IntoResponse, Error> {
@@ -50,7 +50,7 @@ impl OrganizationController {
     /// --data '{"name":"My New Organization"}' \
     /// http://localhost:4000/organizations
     pub async fn create(
-        CheckApiVersion(_v): CheckApiVersion,
+        CompareApiVersion(_v): CompareApiVersion,
         State(app_state): State<AppState>,
         Json(organization_model): Json<organizations::Model>,
     ) -> Result<impl IntoResponse, Error> {
@@ -69,7 +69,7 @@ impl OrganizationController {
     /// --request PUT  http://localhost:4000/organizations/<id> \
     /// --data '{"name":"My Updated Organization"}'
     pub async fn update(
-        CheckApiVersion(_v): CheckApiVersion,
+        CompareApiVersion(_v): CompareApiVersion,
         State(app_state): State<AppState>,
         Path(id): Path<Id>,
         Json(organization_model): Json<organizations::Model>,
@@ -90,7 +90,7 @@ impl OrganizationController {
     /// --request DELETE \
     /// http://localhost:4000/organizations/<id>
     pub async fn delete(
-        CheckApiVersion(_v): CheckApiVersion,
+        CompareApiVersion(_v): CompareApiVersion,
         State(app_state): State<AppState>,
         Path(id): Path<Id>,
     ) -> Result<impl IntoResponse, Error> {

--- a/web/src/custom_extractors.rs
+++ b/web/src/custom_extractors.rs
@@ -28,10 +28,15 @@ where
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let state = AppState::from_ref(state);
         let version = get_x_version(parts)?;
-        let api_version = HeaderValue::from_str(&state.config.api_version.unwrap_or_default()).ok().unwrap();
+        let api_version = HeaderValue::from_str(&state.config.api_version.unwrap_or_default())
+            .ok()
+            .unwrap_or_else(|| HeaderValue::from_static("0.0.0"));
 
         trace!("API version provided by client: {:?}", version);
-        trace!("API version set in AppState.config.api_version: {:?}", version);
+        trace!(
+            "API version set in AppState.config.api_version: {:?}",
+            version
+        );
 
         Ok(is_current_api_version(version, api_version)?)
     }
@@ -45,7 +50,10 @@ fn get_x_version(parts: &mut Parts) -> Result<HeaderValue, RejectionType> {
     }
 }
 
-fn is_current_api_version(version: HeaderValue, api_version: HeaderValue) -> Result<CheckApiVersion, RejectionType> {
+fn is_current_api_version(
+    version: HeaderValue,
+    api_version: HeaderValue,
+) -> Result<CheckApiVersion, RejectionType> {
     if version == api_version {
         Ok(CheckApiVersion(version))
     } else {

--- a/web/src/custom_extractors.rs
+++ b/web/src/custom_extractors.rs
@@ -6,6 +6,8 @@ use axum::{
 };
 use log::*;
 
+type RejectionType = (StatusCode, &'static str);
+
 pub static X_VERSION: &str = "x-version";
 
 pub struct CheckApiVersion(pub HeaderValue);
@@ -16,7 +18,7 @@ where
     AppState: FromRef<S>,
     S: Send + Sync,
 {
-    type Rejection = (StatusCode, &'static str);
+    type Rejection = RejectionType;
 
     // A custom Extractor that extracts and checks that the API version number
     // provided in the "X-Version" header is equal to the API version specified
@@ -25,18 +27,31 @@ where
     // successfully.
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let state = AppState::from_ref(state);
+        let version = get_x_version(parts)?;
+        let api_version = HeaderValue::from_str(&state.config.api_version.unwrap_or_default()).ok().unwrap();
 
-        if let Some(version) = parts.headers.get(X_VERSION) {
-            trace!("API version provided by client: {:?}", version);
-            match state.config.api_version == Some(version.to_str().unwrap_or_default().into()) {
-                true => Ok(CheckApiVersion(version.clone())),
-                false => Err((
-                    StatusCode::BAD_REQUEST,
-                    "`X-Version` header is not a valid API version",
-                )),
-            }
-        } else {
-            Err((StatusCode::BAD_REQUEST, "`X-Version` header is missing"))
-        }
+        trace!("API version provided by client: {:?}", version);
+        trace!("API version set in AppState.config.api_version: {:?}", version);
+
+        Ok(is_current_api_version(version, api_version)?)
+    }
+}
+
+fn get_x_version(parts: &mut Parts) -> Result<HeaderValue, RejectionType> {
+    if let Some(version) = parts.headers.get(X_VERSION) {
+        Ok(version.clone())
+    } else {
+        Err((StatusCode::BAD_REQUEST, "`X-Version` header is missing"))
+    }
+}
+
+fn is_current_api_version(version: HeaderValue, api_version: HeaderValue) -> Result<CheckApiVersion, RejectionType> {
+    if version == api_version {
+        Ok(CheckApiVersion(version))
+    } else {
+        Err((
+            StatusCode::BAD_REQUEST,
+            "`X-Version` header is not a valid API version",
+        ))
     }
 }

--- a/web/src/custom_extractors.rs
+++ b/web/src/custom_extractors.rs
@@ -27,22 +27,15 @@ where
         let state = AppState::from_ref(state);
 
         if let Some(version) = parts.headers.get(X_VERSION) {
-            debug!("API version: {:?}", version);
-            if state.config.api_version == Some(version.to_str().unwrap_or_default().into()) {
-                debug!("Valid API version specified");
-                Ok(CheckApiVersion(version.clone()))
-            } else {
-                error!(
-                    "API version provided is not a valid API version: {:?}",
-                    version
-                );
-                Err((
+            trace!("API version provided by client: {:?}", version);
+            match state.config.api_version == Some(version.to_str().unwrap_or_default().into()) {
+                true => Ok(CheckApiVersion(version.clone())),
+                false => Err((
                     StatusCode::BAD_REQUEST,
                     "`X-Version` header is not a valid API version",
-                ))
+                )),
             }
         } else {
-            error!("API version header not provided");
             Err((StatusCode::BAD_REQUEST, "`X-Version` header is missing"))
         }
     }

--- a/web/src/custom_extractors.rs
+++ b/web/src/custom_extractors.rs
@@ -38,7 +38,7 @@ where
         trace!("API version provided by client: {:?}", version);
         trace!(
             "API version set in AppState.config.api_version: {:?}",
-            version
+            api_version
         );
 
         Ok(is_current_api_version(version, api_version)?)

--- a/web/src/custom_extractors.rs
+++ b/web/src/custom_extractors.rs
@@ -5,6 +5,7 @@ use axum::{
     http::{header::HeaderValue, request::Parts, StatusCode},
 };
 use log::*;
+use service::config::DEFAULT_API_VERSION;
 
 type RejectionType = (StatusCode, &'static str);
 
@@ -27,10 +28,12 @@ where
     // successfully.
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
         let state = AppState::from_ref(state);
+        // Provided by the client in the HTTP header
         let version = get_x_version(parts)?;
-        let api_version = HeaderValue::from_str(&state.config.api_version.unwrap_or_default())
+        // Provided as part of the AppState environment configuration
+        let api_version = HeaderValue::from_str(state.config.api_version())
             .ok()
-            .unwrap_or_else(|| HeaderValue::from_static("0.0.0"));
+            .unwrap_or_else(|| HeaderValue::from_static(DEFAULT_API_VERSION));
 
         trace!("API version provided by client: {:?}", version);
         trace!(

--- a/web/src/custom_extractors.rs
+++ b/web/src/custom_extractors.rs
@@ -1,0 +1,49 @@
+use crate::AppState;
+use axum::{
+    async_trait,
+    extract::{FromRef, FromRequestParts},
+    http::{header::HeaderValue, request::Parts, StatusCode},
+};
+use log::*;
+
+pub static X_VERSION: &str = "x-version";
+
+pub struct CheckApiVersion(pub HeaderValue);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for CheckApiVersion
+where
+    AppState: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = (StatusCode, &'static str);
+
+    // A custom Extractor that extracts and checks that the API version number
+    // provided in the "X-Version" header is equal to the API version specified
+    // in AppState.
+    // If this Extractor fails any Handler methods that use it will not be called
+    // successfully.
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let state = AppState::from_ref(state);
+
+        if let Some(version) = parts.headers.get(X_VERSION) {
+            debug!("API version: {:?}", version);
+            if state.config.api_version == Some(version.to_str().unwrap_or_default().into()) {
+                debug!("Valid API version specified");
+                Ok(CheckApiVersion(version.clone()))
+            } else {
+                error!(
+                    "API version provided is not a valid API version: {:?}",
+                    version
+                );
+                Err((
+                    StatusCode::BAD_REQUEST,
+                    "`X-Version` header is not a valid API version",
+                ))
+            }
+        } else {
+            error!("API version header not provided");
+            Err((StatusCode::BAD_REQUEST, "`X-Version` header is missing"))
+        }
+    }
+}

--- a/web/src/custom_extractors.rs
+++ b/web/src/custom_extractors.rs
@@ -11,10 +11,10 @@ type RejectionType = (StatusCode, &'static str);
 
 pub static X_VERSION: &str = "x-version";
 
-pub struct CheckApiVersion(pub HeaderValue);
+pub struct CompareApiVersion(pub HeaderValue);
 
 #[async_trait]
-impl<S> FromRequestParts<S> for CheckApiVersion
+impl<S> FromRequestParts<S> for CompareApiVersion
 where
     AppState: FromRef<S>,
     S: Send + Sync,
@@ -56,9 +56,9 @@ fn get_x_version(parts: &mut Parts) -> Result<HeaderValue, RejectionType> {
 fn is_current_api_version(
     version: HeaderValue,
     api_version: HeaderValue,
-) -> Result<CheckApiVersion, RejectionType> {
+) -> Result<CompareApiVersion, RejectionType> {
     if version == api_version {
-        Ok(CheckApiVersion(version))
+        Ok(CompareApiVersion(version))
     } else {
         Err((
             StatusCode::BAD_REQUEST,

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -15,6 +15,7 @@ use tokio::net::TcpListener;
 use tower_http::cors::CorsLayer;
 
 mod controller;
+mod custom_extractors;
 mod error;
 mod router;
 

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -21,8 +21,10 @@ pub fn define_routes(app_state: AppState) -> Router {
 
 pub fn organization_routes(app_state: AppState) -> Router {
     Router::new()
-        // TODO: Add an API versioning scheme and prefix all routes with it
-        // See Router::nest() - https://docs.rs/axum/latest/axum/struct.Router.html#method.nest
+        // The goal will be able to do something like the follow Node.js code does for
+        // versioning: https://www.codemzy.com/blog/nodejs-api-versioning
+        // except we can use axum-extras `or` like is show here:
+        // https://gist.github.com/davidpdrsn/eb4e703e7e068ece3efd975b8f6bc340#file-content_type_or-rs-L17
         .route("/organizations", get(OrganizationController::index))
         .route("/organizations/:id", get(OrganizationController::read))
         .route("/organizations", post(OrganizationController::create))


### PR DESCRIPTION
## Description
Adds a custom Extractor that checks for a valid API version set in a client request header before calling the endpoint's handler. This enables us to call certain route handlers for different versions, and allows us to know the current version in a handler and do different functionality depending on the version number.

#### GitHub Issue: Closes #43 

### Changes
* Adds a new CheckApiExtractor that looks for the `X-Version` header and compares that to the current version of the API we've set in `AppState.config.api_version`
* Modifies tests to include this new client header

### Testing Strategy
Run `cargo test`, if it passes it's successfully used the `X-Version` header


### Concerns
None
