### PR TITLE
Add OpenAPI documentation for the platform endpoints using utoipa

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2905,11 +2905,13 @@ dependencies = [
  "clap",
  "log",
  "sea-orm",
+ "serde",
  "serde_json",
  "simplelog",
  "sqlx",
  "tokio",
  "tower",
+ "utoipa",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3841,6 +3841,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "utoipa-rapidoc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e79a75396496e4fe41359375a67e8fcb9c28444cd1cb5e8ac54f47684e64290"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
+
+[[package]]
+name = "utoipa-redoc"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5ab3f28191a1881d747bc7c5205a2e51ce5647c97944ac67c23a3f4f1afae10"
+dependencies = [
+ "axum",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
+
+[[package]]
 name = "utoipa-swagger-ui"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4004,6 +4028,8 @@ dependencies = [
  "tower-http",
  "tower-sessions",
  "utoipa",
+ "utoipa-rapidoc",
+ "utoipa-redoc",
  "utoipa-swagger-ui",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,15 +784,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
-name = "crc32fast"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "crossbeam-queue"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -989,16 +980,6 @@ name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
-
-[[package]]
-name = "flate2"
-version = "1.0.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "flume"
@@ -2499,40 +2480,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-embed"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb78f46d0066053d16d4ca7b898e9343bc3530f71c61d5ad84cd404ada068745"
-dependencies = [
- "rust-embed-impl",
- "rust-embed-utils",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-impl"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91ac2a3c6c0520a3fb3dd89321177c3c692937c4eb21893378219da10c44fc8"
-dependencies = [
- "proc-macro2",
- "quote",
- "rust-embed-utils",
- "syn 2.0.48",
- "walkdir",
-]
-
-[[package]]
-name = "rust-embed-utils"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f69089032567ffff4eada41c573fc43ff466c7db7c5688b2e7969584345581"
-dependencies = [
- "sha2",
- "walkdir",
-]
-
-[[package]]
 name = "rust_decimal"
 version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2622,15 +2569,6 @@ name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
 
 [[package]]
 name = "schannel"
@@ -3866,22 +3804,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utoipa-swagger-ui"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b39868d43c011961e04b41623e050aedf2cc93652562ff7935ce0f819aaf2da"
-dependencies = [
- "axum",
- "mime_guess",
- "regex",
- "rust-embed",
- "serde",
- "serde_json",
- "utoipa",
- "zip",
-]
-
-[[package]]
 name = "uuid"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3914,16 +3836,6 @@ name = "waker-fn"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
-
-[[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
 
 [[package]]
 name = "want"
@@ -4030,7 +3942,6 @@ dependencies = [
  "tower-sessions",
  "utoipa",
  "utoipa-rapidoc",
- "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -4280,15 +4191,3 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
-
-[[package]]
-name = "zip"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
-dependencies = [
- "byteorder",
- "crc32fast",
- "crossbeam-utils",
- "flate2",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -784,6 +784,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
+name = "crc32fast"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3855a8a784b474f333699ef2bbca9db2c4a1f6d9088a90a2d25b1eb53111eaa"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,6 +893,7 @@ dependencies = [
  "chrono",
  "sea-orm",
  "serde",
+ "utoipa",
  "uuid",
 ]
 
@@ -978,6 +988,16 @@ name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fcfdc7a0362c9f4444381a9e697c79d435fe65b52a37466fc2c1184cee9edc6"
+
+[[package]]
+name = "flate2"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46303f565772937ffe1d394a4fac6f411c6013172fadde9dcdb1e147a086940e"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "flume"
@@ -1524,6 +1544,7 @@ checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.3",
+ "serde",
 ]
 
 [[package]]
@@ -2477,6 +2498,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-embed"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb78f46d0066053d16d4ca7b898e9343bc3530f71c61d5ad84cd404ada068745"
+dependencies = [
+ "rust-embed-impl",
+ "rust-embed-utils",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-impl"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91ac2a3c6c0520a3fb3dd89321177c3c692937c4eb21893378219da10c44fc8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rust-embed-utils",
+ "syn 2.0.48",
+ "walkdir",
+]
+
+[[package]]
+name = "rust-embed-utils"
+version = "8.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86f69089032567ffff4eada41c573fc43ff466c7db7c5688b2e7969584345581"
+dependencies = [
+ "sha2",
+ "walkdir",
+]
+
+[[package]]
 name = "rust_decimal"
 version = "1.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2621,15 @@ name = "ryu"
 version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f98d2aa92eebf49b69786be48e4477826b256916e84a57ff2a4f21923b48eb4c"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -3751,6 +3815,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
+name = "utoipa"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "272ebdfbc99111033031d2f10e018836056e4d2c8e2acda76450ec7974269fa7"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3c9f4d08338c1bfa70dde39412a040a884c6f318b3d09aaaf3437a1e52027fc"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "syn 2.0.48",
+ "uuid",
+]
+
+[[package]]
+name = "utoipa-swagger-ui"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b39868d43c011961e04b41623e050aedf2cc93652562ff7935ce0f819aaf2da"
+dependencies = [
+ "axum",
+ "mime_guess",
+ "regex",
+ "rust-embed",
+ "serde",
+ "serde_json",
+ "utoipa",
+ "zip",
+]
+
+[[package]]
 name = "uuid"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3783,6 +3889,16 @@ name = "waker-fn"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -3887,6 +4003,8 @@ dependencies = [
  "tower",
  "tower-http",
  "tower-sessions",
+ "utoipa",
+ "utoipa-swagger-ui",
 ]
 
 [[package]]
@@ -4136,3 +4254,15 @@ name = "zeroize"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525b4ec142c6b68a2d10f01f7bbf6755599ca3f81ea53b8431b7dd348f5fdb2d"
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3854,18 +3854,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "utoipa-redoc"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5ab3f28191a1881d747bc7c5205a2e51ce5647c97944ac67c23a3f4f1afae10"
-dependencies = [
- "axum",
- "serde",
- "serde_json",
- "utoipa",
-]
-
-[[package]]
 name = "utoipa-swagger-ui"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4030,7 +4018,6 @@ dependencies = [
  "tower-sessions",
  "utoipa",
  "utoipa-rapidoc",
- "utoipa-redoc",
  "utoipa-swagger-ui",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,6 +2846,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.195"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2905,6 +2914,7 @@ dependencies = [
  "clap",
  "log",
  "sea-orm",
+ "semver",
  "serde",
  "serde_json",
  "simplelog",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -912,6 +912,7 @@ dependencies = [
  "serde_json",
  "service",
  "tokio",
+ "utoipa",
 ]
 
 [[package]]

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 axum-login = "0.12.0"
 chrono = { version = "0.4.34", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
+utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }
 uuid = "1.7.0"
 
 [dependencies.sea-orm]

--- a/entity/src/organizations.rs
+++ b/entity/src/organizations.rs
@@ -2,8 +2,10 @@
 
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, ToSchema, Serialize, Deserialize)]
+#[schema(as = entity::organizations::Model)] // OpenAPI schema
 #[sea_orm(schema_name = "refactor_platform", table_name = "organizations")]
 pub struct Model {
     #[sea_orm(primary_key)]
@@ -13,7 +15,9 @@ pub struct Model {
     pub external_id: Uuid,
     pub name: Option<String>,
     pub logo: Option<String>,
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub created_at: DateTimeWithTimeZone,
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub updated_at: DateTimeWithTimeZone,
 }
 

--- a/entity/src/users.rs
+++ b/entity/src/users.rs
@@ -4,8 +4,10 @@ use crate::Id;
 use axum_login::AuthUser;
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, ToSchema, Serialize, Deserialize)]
+#[schema(as = entity::users::Model)] // OpenAPI schema
 #[sea_orm(schema_name = "refactor_platform", table_name = "users")]
 pub struct Model {
     #[sea_orm(primary_key)]
@@ -18,10 +20,13 @@ pub struct Model {
     pub first_name: Option<String>,
     pub last_name: Option<String>,
     pub display_name: Option<String>,
+    #[serde(skip)]
     pub password: String,
     pub github_username: Option<String>,
     pub github_profile_url: Option<String>,
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub created_at: DateTimeWithTimeZone,
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub updated_at: DateTimeWithTimeZone,
 }
 

--- a/entity_api/Cargo.toml
+++ b/entity_api/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4.20"
 axum-login = "0.12.0"
 async-trait = "0.1.76"
 password-auth = "1.0.0"
+utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }
 
 [dependencies.sea-orm]
 version = "0.12" # sea-orm version

--- a/entity_api/src/user.rs
+++ b/entity_api/src/user.rs
@@ -7,6 +7,7 @@ use password_auth::{generate_hash, verify_password};
 use sea_orm::{entity::prelude::*, prelude::Uuid, sea_query, ActiveValue, DatabaseConnection};
 use serde::Deserialize;
 use std::sync::Arc;
+use utoipa::ToSchema;
 
 use crate::user::Entity;
 
@@ -36,7 +37,8 @@ pub struct Backend {
     db: Arc<DatabaseConnection>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, ToSchema, Deserialize)]
+#[schema(as = entity_api::user::Credentials)] // OpenAPI schema
 pub struct Credentials {
     pub email: String,
     pub password: String,

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -18,7 +18,9 @@ features = [
 clap = { version = "4.4.6", features = ["cargo", "derive", "env"] }
 log = "0.4"
 simplelog = { version = "0.12", features = ["paris"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.107"
 sqlx = { version = "0.7.3", features = ["time", "runtime-tokio"] }
 tokio = { version = "1.35", features = ["full"] }
 tower = "0.4.13"
+utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -24,3 +24,4 @@ sqlx = { version = "0.7.3", features = ["time", "runtime-tokio"] }
 tokio = { version = "1.35", features = ["full"] }
 tower = "0.4.13"
 utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }
+semver = { version = "1.0.22", features = ["serde"] }

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -1,11 +1,25 @@
 use clap::builder::TypedValueParser as _;
 use clap::Parser;
 use log::LevelFilter;
+use serde::Deserialize;
+use utoipa::IntoParams;
 
-pub const DEFAULT_API_VERSION: &str = "0.0.1";
+type APiVersionList = [&'static str; 1];
+
+const DEFAULT_API_VERSION: &str = "0.0.1";
 // Expand this array to include all valid API versions. Versions that have been
 // completely removed should be removed from this list - they're no longer valid.
-pub const API_VERSIONS: [&str; 1] = [DEFAULT_API_VERSION];
+const API_VERSIONS: APiVersionList = [DEFAULT_API_VERSION];
+
+static X_VERSION: &str = "x-version";
+
+#[derive(Deserialize, IntoParams)]
+#[into_params(parameter_in = Header)]
+pub struct ApiVersion {
+    /// The version of the API to use for a request.
+    #[param(rename = "x-version", style = Simple, required, example = "0.0.1")]
+    pub version: &'static str,
+}
 
 #[derive(Clone, Debug, Parser)]
 #[command(author, version, about, long_about = None)]
@@ -72,5 +86,37 @@ impl Config {
         self.database_uri
             .as_ref()
             .expect("No Database URI Provided")
+    }
+}
+
+impl ApiVersion {
+    pub fn new(version_str: &'static str) -> Self {
+        ApiVersion {
+            version: version_str,
+        }
+    }
+
+    pub fn default_version() -> &'static str {
+        DEFAULT_API_VERSION
+    }
+
+    pub fn field_name() -> &'static str {
+        X_VERSION
+    }
+
+    pub fn versions() -> APiVersionList {
+        API_VERSIONS
+    }
+
+    pub fn as_str(&self) -> &str {
+        self.version
+    }
+}
+
+impl Default for ApiVersion {
+    fn default() -> Self {
+        ApiVersion {
+            version: DEFAULT_API_VERSION,
+        }
     }
 }

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -1,6 +1,7 @@
 use clap::builder::TypedValueParser as _;
 use clap::Parser;
 use log::LevelFilter;
+use semver::{BuildMetadata, Prerelease, Version};
 use serde::Deserialize;
 use utoipa::IntoParams;
 
@@ -18,7 +19,7 @@ static X_VERSION: &str = "x-version";
 pub struct ApiVersion {
     /// The version of the API to use for a request.
     #[param(rename = "x-version", style = Simple, required, example = "0.0.1")]
-    pub version: &'static str,
+    pub version: Version,
 }
 
 #[derive(Clone, Debug, Parser)]
@@ -92,7 +93,13 @@ impl Config {
 impl ApiVersion {
     pub fn new(version_str: &'static str) -> Self {
         ApiVersion {
-            version: version_str,
+            version: Version::parse(version_str).unwrap_or(Version {
+                major: 0,
+                minor: 0,
+                patch: 1,
+                pre: Prerelease::EMPTY,
+                build: BuildMetadata::EMPTY,
+            }),
         }
     }
 
@@ -108,15 +115,21 @@ impl ApiVersion {
         API_VERSIONS
     }
 
-    pub fn as_str(&self) -> &str {
-        self.version
+    pub fn to_string(&self) -> String {
+        self.version.to_string()
     }
 }
 
 impl Default for ApiVersion {
     fn default() -> Self {
         ApiVersion {
-            version: DEFAULT_API_VERSION,
+            version: Version::parse(DEFAULT_API_VERSION).unwrap_or(Version {
+                major: 0,
+                minor: 0,
+                patch: 1,
+                pre: Prerelease::EMPTY,
+                build: BuildMetadata::EMPTY,
+            }),
         }
     }
 }

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use log::LevelFilter;
 use semver::{BuildMetadata, Prerelease, Version};
 use serde::Deserialize;
+use std::fmt;
 use utoipa::IntoParams;
 
 type APiVersionList = [&'static str; 1];
@@ -114,10 +115,6 @@ impl ApiVersion {
     pub fn versions() -> APiVersionList {
         API_VERSIONS
     }
-
-    pub fn to_string(&self) -> String {
-        self.version.to_string()
-    }
 }
 
 impl Default for ApiVersion {
@@ -131,5 +128,11 @@ impl Default for ApiVersion {
                 build: BuildMetadata::EMPTY,
             }),
         }
+    }
+}
+
+impl fmt::Display for ApiVersion {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.version)
     }
 }

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -22,6 +22,8 @@ tower-sessions = { version = "0.9", features = ["postgres-store", "deletion-task
 time = "0.3.31"
 utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }
 utoipa-swagger-ui = { version = "6.0.0", features = ["axum"] }
+utoipa-rapidoc = { version = "3.0.0", features = ["axum"] }
+utoipa-redoc = { version = "3.0.0", features = ["axum"] }
 
 [dependencies.sea-orm]
 version = "0.12" # sea-orm version

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -20,6 +20,8 @@ tokio = { version = "1.35.0", features = ["full"] }
 tower = "0.4.13"
 tower-sessions = { version = "0.9", features = ["postgres-store", "deletion-task"]}
 time = "0.3.31"
+utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }
+utoipa-swagger-ui = { version = "6.0.0", features = ["axum"] }
 
 [dependencies.sea-orm]
 version = "0.12" # sea-orm version

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -21,7 +21,6 @@ tower = "0.4.13"
 tower-sessions = { version = "0.9", features = ["postgres-store", "deletion-task"]}
 time = "0.3.31"
 utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }
-utoipa-swagger-ui = { version = "6.0.0", features = ["axum"] }
 utoipa-rapidoc = { version = "3.0.0", features = ["axum"] }
 
 [dependencies.sea-orm]

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -23,7 +23,6 @@ time = "0.3.31"
 utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }
 utoipa-swagger-ui = { version = "6.0.0", features = ["axum"] }
 utoipa-rapidoc = { version = "3.0.0", features = ["axum"] }
-utoipa-redoc = { version = "3.0.0", features = ["axum"] }
 
 [dependencies.sea-orm]
 version = "0.12" # sea-orm version

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -8,95 +8,113 @@ use serde_json::json;
 
 use log::*;
 
-pub struct OrganizationController {}
+/// GET all Organizations
+/// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
+/// --request GET \
+/// http://localhost:4000/organizations
+#[utoipa::path(
+        get,
+        path = "/organizations",
+        responses(
+            (status = 200, description = "List all Organizations successfully", body = [entity::organizations::Model]),
+            (status = 401, description = "Unauthorized"),
+            (status = 405, description = "Method not allowed (CORS)")
+        )
+    )]
+pub async fn index(
+    CompareApiVersion(_v): CompareApiVersion,
+    State(app_state): State<AppState>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("GET all Organizations");
+    let organizations = OrganizationApi::find_all(app_state.db_conn_ref()).await?;
 
-impl OrganizationController {
-    /// GET all Organizations
-    /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
-    /// --request GET \
-    /// http://localhost:4000/organizations
-    pub async fn index(
-        CompareApiVersion(_v): CompareApiVersion,
-        State(app_state): State<AppState>,
-    ) -> Result<impl IntoResponse, Error> {
-        debug!("GET all Organizations");
-        let organizations = OrganizationApi::find_all(app_state.db_conn_ref()).await?;
+    debug!("Found Organizations: {:?}", organizations);
 
-        debug!("Found Organizations: {:?}", organizations);
+    Ok(Json(organizations))
+}
 
-        Ok(Json(organizations))
-    }
+/// GET a particular Organization entity specified by its primary key
+/// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
+/// --request GET \
+/// http://localhost:4000/organizations/<id>
+#[utoipa::path(
+get,
+path = "/organizations/{id}",
+params(
+    ("id" = Id, Path, description = "Organization id")
+),
+responses(
+    (status = 200, description = "Got a particular Organization entity by its id successfully", body = [entity::organizations::Model]),
+    (status = 404, description = "Organization not found"),
+    (status = 401, description = "Unauthorized"),
+    (status = 405, description = "Method not allowed (CORS)")
+)
+)]
+pub async fn read(
+    CompareApiVersion(_v): CompareApiVersion,
+    State(app_state): State<AppState>,
+    Path(id): Path<Id>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("GET Organization by id: {}", id);
 
-    /// GET a particular Organization entity specified by its primary key
-    /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
-    /// --request GET \
-    /// http://localhost:4000/organizations/<id>
-    pub async fn read(
-        CompareApiVersion(_v): CompareApiVersion,
-        State(app_state): State<AppState>,
-        Path(id): Path<Id>,
-    ) -> Result<impl IntoResponse, Error> {
-        debug!("GET Organization by id: {}", id);
+    let organization: Option<organizations::Model> =
+        OrganizationApi::find_by_id(app_state.db_conn_ref(), id).await?;
 
-        let organization: Option<organizations::Model> =
-            OrganizationApi::find_by_id(app_state.db_conn_ref(), id).await?;
+    Ok(Json(organization))
+}
 
-        Ok(Json(organization))
-    }
+/// CREATE a new Organization entity
+/// Test this with curl: curl --header "Content-Type: application/json" \
+/// --request POST \
+/// --data '{"name":"My New Organization"}' \
+/// http://localhost:4000/organizations
+pub async fn create(
+    CompareApiVersion(_v): CompareApiVersion,
+    State(app_state): State<AppState>,
+    Json(organization_model): Json<organizations::Model>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("CREATE new Organization: {:?}", organization_model.name);
 
-    /// CREATE a new Organization entity
-    /// Test this with curl: curl --header "Content-Type: application/json" \
-    /// --request POST \
-    /// --data '{"name":"My New Organization"}' \
-    /// http://localhost:4000/organizations
-    pub async fn create(
-        CompareApiVersion(_v): CompareApiVersion,
-        State(app_state): State<AppState>,
-        Json(organization_model): Json<organizations::Model>,
-    ) -> Result<impl IntoResponse, Error> {
-        debug!("CREATE new Organization: {:?}", organization_model.name);
+    let organization: organizations::Model =
+        OrganizationApi::create(app_state.db_conn_ref(), organization_model).await?;
 
-        let organization: organizations::Model =
-            OrganizationApi::create(app_state.db_conn_ref(), organization_model).await?;
+    debug!("Newly Created Organization: {:?}", &organization);
 
-        debug!("Newly Created Organization: {:?}", &organization);
+    Ok(Json(organization))
+}
 
-        Ok(Json(organization))
-    }
+/// UPDATE a particular Organization entity specified by its primary key
+/// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
+/// --request PUT  http://localhost:4000/organizations/<id> \
+/// --data '{"name":"My Updated Organization"}'
+pub async fn update(
+    CompareApiVersion(_v): CompareApiVersion,
+    State(app_state): State<AppState>,
+    Path(id): Path<Id>,
+    Json(organization_model): Json<organizations::Model>,
+) -> Result<impl IntoResponse, Error> {
+    debug!(
+        "UPDATE the entire Organization by id: {:?}, new name: {:?}",
+        id, organization_model.name
+    );
 
-    /// UPDATE a particular Organization entity specified by its primary key
-    /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
-    /// --request PUT  http://localhost:4000/organizations/<id> \
-    /// --data '{"name":"My Updated Organization"}'
-    pub async fn update(
-        CompareApiVersion(_v): CompareApiVersion,
-        State(app_state): State<AppState>,
-        Path(id): Path<Id>,
-        Json(organization_model): Json<organizations::Model>,
-    ) -> Result<impl IntoResponse, Error> {
-        debug!(
-            "UPDATE the entire Organization by id: {:?}, new name: {:?}",
-            id, organization_model.name
-        );
+    let updated_organization: organizations::Model =
+        OrganizationApi::update(app_state.db_conn_ref(), id, organization_model).await?;
 
-        let updated_organization: organizations::Model =
-            OrganizationApi::update(app_state.db_conn_ref(), id, organization_model).await?;
+    Ok(Json(updated_organization))
+}
 
-        Ok(Json(updated_organization))
-    }
+/// DELETE an Organization entity specified by its primary key
+/// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
+/// --request DELETE \
+/// http://localhost:4000/organizations/<id>
+pub async fn delete(
+    CompareApiVersion(_v): CompareApiVersion,
+    State(app_state): State<AppState>,
+    Path(id): Path<Id>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("DELETE Organization by id: {}", id);
 
-    /// DELETE an Organization entity specified by its primary key
-    /// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
-    /// --request DELETE \
-    /// http://localhost:4000/organizations/<id>
-    pub async fn delete(
-        CompareApiVersion(_v): CompareApiVersion,
-        State(app_state): State<AppState>,
-        Path(id): Path<Id>,
-    ) -> Result<impl IntoResponse, Error> {
-        debug!("DELETE Organization by id: {}", id);
-
-        OrganizationApi::delete_by_id(app_state.db_conn_ref(), id).await?;
-        Ok(Json(json!({"id": id})))
-    }
+    OrganizationApi::delete_by_id(app_state.db_conn_ref(), id).await?;
+    Ok(Json(json!({"id": id})))
 }

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -8,17 +8,17 @@ use serde_json::json;
 
 use log::*;
 
-/// GET all Organizations
-/// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
-/// --request GET \
-/// http://localhost:4000/organizations
+/// GET all Organizations.
 #[utoipa::path(
         get,
         path = "/organizations",
         responses(
-            (status = 200, description = "List all Organizations successfully", body = [entity::organizations::Model]),
+            (status = 200, description = "Successfully retrieved all Organizations", body = [entity::organizations::Model]),
             (status = 401, description = "Unauthorized"),
-            (status = 405, description = "Method not allowed (CORS)")
+            (status = 405, description = "Method not allowed")
+        ),
+        security(
+            ("cookie_auth" = [])
         )
     )]
 pub async fn index(
@@ -33,22 +33,22 @@ pub async fn index(
     Ok(Json(organizations))
 }
 
-/// GET a particular Organization entity specified by its primary key
-/// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
-/// --request GET \
-/// http://localhost:4000/organizations/<id>
+/// GET a particular Organization specified by its primary key.
 #[utoipa::path(
-get,
-path = "/organizations/{id}",
-params(
-    ("id" = Id, Path, description = "Organization id")
-),
-responses(
-    (status = 200, description = "Got a particular Organization entity by its id successfully", body = [entity::organizations::Model]),
-    (status = 404, description = "Organization not found"),
-    (status = 401, description = "Unauthorized"),
-    (status = 405, description = "Method not allowed (CORS)")
-)
+    get,
+    path = "/organizations/{id}",
+    params(
+        ("id" = i32, Path, description = "Organization id to retrieve")
+    ),
+    responses(
+        (status = 200, description = "Successfully retrieved a certain Organization by its id", body = [entity::organizations::Model]),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Organization not found"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
 )]
 pub async fn read(
     CompareApiVersion(_v): CompareApiVersion,
@@ -63,11 +63,20 @@ pub async fn read(
     Ok(Json(organization))
 }
 
-/// CREATE a new Organization entity
-/// Test this with curl: curl --header "Content-Type: application/json" \
-/// --request POST \
-/// --data '{"name":"My New Organization"}' \
-/// http://localhost:4000/organizations
+/// CREATE a new Organization.
+#[utoipa::path(
+    post,
+    path = "/organizations",
+    request_body = entity::organizations::Model,
+    responses(
+        (status = 200, description = "Successfully created a new Organization", body = [entity::organizations::Model]),
+        (status = 401, description = "Unauthorized"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+    )]
 pub async fn create(
     CompareApiVersion(_v): CompareApiVersion,
     State(app_state): State<AppState>,
@@ -83,15 +92,29 @@ pub async fn create(
     Ok(Json(organization))
 }
 
-/// UPDATE a particular Organization entity specified by its primary key
-/// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
-/// --request PUT  http://localhost:4000/organizations/<id> \
-/// --data '{"name":"My Updated Organization"}'
+/// UPDATE a particular Organization specified by its primary key.
+#[utoipa::path(
+    put,
+    path = "/organizations/{id}",
+    params(
+        ("id" = i32, Path, description = "Organization id to update")
+    ),
+    request_body = entity::organizations::Model,
+    responses(
+        (status = 200, description = "Successfully updated a certain Organization by its id", body = [entity::organizations::Model]),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Organization not found"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
 pub async fn update(
     CompareApiVersion(_v): CompareApiVersion,
     State(app_state): State<AppState>,
     Path(id): Path<Id>,
-    Json(organization_model): Json<organizations::Model>,
+    Json(organization_model): Json<entity::organizations::Model>,
 ) -> Result<impl IntoResponse, Error> {
     debug!(
         "UPDATE the entire Organization by id: {:?}, new name: {:?}",
@@ -104,10 +127,23 @@ pub async fn update(
     Ok(Json(updated_organization))
 }
 
-/// DELETE an Organization entity specified by its primary key
-/// Test this with curl: curl --header "Content-Type: application/json" \                                                                                         in zsh at 12:03:06
-/// --request DELETE \
-/// http://localhost:4000/organizations/<id>
+/// DELETE an Organization specified by its primary key.
+#[utoipa::path(
+    delete,
+    path = "/organizations/{id}",
+    params(
+        ("id" = i32, Path, description = "Organization id to update")
+    ),
+    responses(
+        (status = 200, description = "Successfully deleted a certain Organization by its id", body = [i32]),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Organization not found"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
 pub async fn delete(
     CompareApiVersion(_v): CompareApiVersion,
     State(app_state): State<AppState>,

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -5,22 +5,26 @@ use axum::Json;
 use entity::{organizations, Id};
 use entity_api::organization as OrganizationApi;
 use serde_json::json;
+use service::config::ApiVersion;
 
 use log::*;
 
 /// GET all Organizations.
 #[utoipa::path(
-        get,
-        path = "/organizations",
-        responses(
-            (status = 200, description = "Successfully retrieved all Organizations", body = [entity::organizations::Model]),
-            (status = 401, description = "Unauthorized"),
-            (status = 405, description = "Method not allowed")
-        ),
-        security(
-            ("cookie_auth" = [])
-        )
-    )]
+    get,
+    path = "/organizations",
+    params(
+        ApiVersion,
+    ),
+    responses(
+        (status = 200, description = "Successfully retrieved all Organizations", body = [entity::organizations::Model]),
+        (status = 401, description = "Unauthorized"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
 pub async fn index(
     CompareApiVersion(_v): CompareApiVersion,
     State(app_state): State<AppState>,
@@ -38,6 +42,7 @@ pub async fn index(
     get,
     path = "/organizations/{id}",
     params(
+        ApiVersion,
         ("id" = i32, Path, description = "Organization id to retrieve")
     ),
     responses(
@@ -67,6 +72,9 @@ pub async fn read(
 #[utoipa::path(
     post,
     path = "/organizations",
+    params(
+        ApiVersion,
+    ),
     request_body = entity::organizations::Model,
     responses(
         (status = 200, description = "Successfully created a new Organization", body = [entity::organizations::Model]),
@@ -97,6 +105,7 @@ pub async fn create(
     put,
     path = "/organizations/{id}",
     params(
+        ApiVersion,
         ("id" = i32, Path, description = "Organization id to update")
     ),
     request_body = entity::organizations::Model,
@@ -132,6 +141,7 @@ pub async fn update(
     delete,
     path = "/organizations/{id}",
     params(
+        ApiVersion,
         ("id" = i32, Path, description = "Organization id to update")
     ),
     responses(

--- a/web/src/controller/user_session_controller.rs
+++ b/web/src/controller/user_session_controller.rs
@@ -11,65 +11,61 @@ pub struct NextUrl {
     _next: Option<String>,
 }
 
-pub struct UserSessionController {}
+pub async fn protected(auth_session: UserApi::AuthSession) -> impl IntoResponse {
+    debug!("UserSessionController::protected()");
 
-impl UserSessionController {
-    pub async fn protected(auth_session: UserApi::AuthSession) -> impl IntoResponse {
-        debug!("UserSessionController::protected()");
+    match auth_session.user {
+        Some(user) => json!({
+            "email": &user.email,
+        })
+        .to_string()
+        .into_response(),
 
-        match auth_session.user {
-            Some(user) => json!({
-                "email": &user.email,
-            })
-            .to_string()
-            .into_response(),
+        None => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
 
-            None => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-        }
+/// curl -v --header "Content-Type: application/x-www-form-urlencoded" \
+/// --data "username=james.hodapp@gmail.com&password=password1&next=organizations" \
+/// http://localhost:4000/login
+///
+/// Successful login will return a session cookie with id, e.g.:
+/// set-cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df; HttpOnly; SameSite=Strict; Path=/; Max-Age=86399
+///
+/// After logging in successfully, you must pass the session id back to the server for
+/// every API call, e.g.:
+/// curl -v --header "Cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df" --request GET http://localhost:4000/organizations
+pub async fn login(
+    mut auth_session: UserApi::AuthSession,
+    Form(creds): Form<UserApi::Credentials>,
+) -> impl IntoResponse {
+    debug!("UserSessionController::login()");
+    let user = match auth_session.authenticate(creds.clone()).await {
+        Ok(Some(user)) => user,
+        Ok(None) => return Err(StatusCode::UNAUTHORIZED.into_response()),
+        Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response()),
+    };
+
+    if auth_session.login(&user).await.is_err() {
+        return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
     }
 
-    /// curl -v --header "Content-Type: application/x-www-form-urlencoded" \
-    /// --data "username=james.hodapp@gmail.com&password=password1&next=organizations" \
-    /// http://localhost:4000/login
-    ///
-    /// Successful login will return a session cookie with id, e.g.:
-    /// set-cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df; HttpOnly; SameSite=Strict; Path=/; Max-Age=86399
-    ///
-    /// After logging in successfully, you must pass the session id back to the server for
-    /// every API call, e.g.:
-    /// curl -v --header "Cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df" --request GET http://localhost:4000/organizations
-    pub async fn login(
-        mut auth_session: UserApi::AuthSession,
-        Form(creds): Form<UserApi::Credentials>,
-    ) -> impl IntoResponse {
-        debug!("UserSessionController::login()");
-        let user = match auth_session.authenticate(creds.clone()).await {
-            Ok(Some(user)) => user,
-            Ok(None) => return Err(StatusCode::UNAUTHORIZED.into_response()),
-            Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response()),
-        };
-
-        if auth_session.login(&user).await.is_err() {
-            return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
-        }
-
-        let response_json = Json(
-            json!({"first_name": user.first_name, "last_name": user.last_name, 
+    let response_json = Json(
+        json!({"first_name": user.first_name, "last_name": user.last_name, 
                 "email": user.email, "display_name": user.display_name}),
-        );
-        debug!("JSON response with 200 OK: {:?}", response_json);
-        Ok(response_json.into_response())
-    }
+    );
+    debug!("JSON response with 200 OK: {:?}", response_json);
+    Ok(response_json.into_response())
+}
 
-    /// Logs the user out of the platform by destroying their session.
-    /// Test this with curl: curl -v \
-    /// --header "Cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df" \
-    /// --request GET http://localhost:4000/logout
-    pub async fn logout(mut auth_session: UserApi::AuthSession) -> impl IntoResponse {
-        debug!("UserSessionController::logout()");
-        match auth_session.logout().await {
-            Ok(_) => StatusCode::OK.into_response(),
-            Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-        }
+/// Logs the user out of the platform by destroying their session.
+/// Test this with curl: curl -v \
+/// --header "Cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df" \
+/// --request GET http://localhost:4000/logout
+pub async fn logout(mut auth_session: UserApi::AuthSession) -> impl IntoResponse {
+    debug!("UserSessionController::logout()");
+    match auth_session.logout().await {
+        Ok(_) => StatusCode::OK.into_response(),
+        Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }

--- a/web/src/controller/user_session_controller.rs
+++ b/web/src/controller/user_session_controller.rs
@@ -25,9 +25,7 @@ pub async fn protected(auth_session: UserApi::AuthSession) -> impl IntoResponse 
     }
 }
 
-/// curl -v --header "Content-Type: application/x-www-form-urlencoded" \
-/// --data "username=james.hodapp@gmail.com&password=password1&next=organizations" \
-/// http://localhost:4000/login
+/// Logs the user into the platform and returns a new session cookie.
 ///
 /// Successful login will return a session cookie with id, e.g.:
 /// set-cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df; HttpOnly; SameSite=Strict; Path=/; Max-Age=86399
@@ -35,6 +33,19 @@ pub async fn protected(auth_session: UserApi::AuthSession) -> impl IntoResponse 
 /// After logging in successfully, you must pass the session id back to the server for
 /// every API call, e.g.:
 /// curl -v --header "Cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df" --request GET http://localhost:4000/organizations
+#[utoipa::path(
+    post,
+    path = "/login",
+    request_body(content = entity_api::user::Credentials, content_type = "application/x-www-form-urlencoded"),
+    responses(
+        (status = 200, description = "Logs in and returns session authentication cookie"),
+        (status = 401, description = "Unauthorized"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
 pub async fn login(
     mut auth_session: UserApi::AuthSession,
     Form(creds): Form<UserApi::Credentials>,
@@ -62,6 +73,18 @@ pub async fn login(
 /// Test this with curl: curl -v \
 /// --header "Cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df" \
 /// --request GET http://localhost:4000/logout
+#[utoipa::path(
+get,
+path = "/logout",
+responses(
+    (status = 200, description = "Successfully logged out"),
+    (status = 401, description = "Unauthorized"),
+    (status = 405, description = "Method not allowed")
+),
+security(
+    ("cookie_auth" = [])
+)
+)]
 pub async fn logout(mut auth_session: UserApi::AuthSession) -> impl IntoResponse {
     debug!("UserSessionController::logout()");
     match auth_session.logout().await {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -67,7 +67,8 @@ pub async fn init_server(app_state: AppState) -> Result<()> {
             Method::PATCH,
         ])
         .allow_credentials(true)
-        .allow_origin("http://localhost:3000".parse::<HeaderValue>().unwrap());
+        .allow_origin("http://localhost:3000".parse::<HeaderValue>().unwrap())
+        .allow_origin("http://localhost:4000".parse::<HeaderValue>().unwrap());
 
     axum::serve(
         listener,

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -69,9 +69,7 @@ pub fn define_routes(app_state: AppState) -> Router {
         .merge(session_routes())
         .merge(protected_routes())
         // FIXME: protect the OpenAPI web UI
-        // There is no need to create `RapiDoc::with_openapi` because the OpenApi is served
-        // via SwaggerUi instead we only make rapidoc to point to the existing doc.
-        .merge(RapiDoc::new("/api-docs/openapi.json").path("/rapidoc"))
+        .merge(RapiDoc::with_openapi("/api-docs/openapi2.json", ApiDoc::openapi()).path("/rapidoc"))
         .fallback_service(static_routes())
 }
 

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -117,8 +117,6 @@ pub fn static_routes() -> Router {
 // see https://github.com/SeaQL/sea-orm/issues/830
 #[cfg(feature = "mock")]
 mod organization_endpoints_tests {
-    use crate::custom_extractors::X_VERSION;
-
     use super::*;
     use anyhow::Ok;
     use axum_login::{
@@ -130,13 +128,13 @@ mod organization_endpoints_tests {
     use entity_api::user::Backend;
     use log::{debug, LevelFilter};
     use password_auth::generate_hash;
-    use reqwest::{header, Url};
+    use reqwest::{header, header::HeaderValue, Url};
     use sea_orm::{
         prelude::Uuid, DatabaseBackend, DatabaseConnection, MockDatabase, MockExecResult,
     };
     use serde_json::json;
     use service::{
-        config::{Config, DEFAULT_API_VERSION},
+        config::{ApiVersion, Config},
         logging::Logger,
     };
     use std::{net::SocketAddr, sync::Arc, sync::Once};
@@ -189,7 +187,10 @@ mod organization_endpoints_tests {
             let mut headers = header::HeaderMap::new();
             // Note: we don't actually need to manually set the server's current AppState.config.api_version
             // since CLAP sets the default value which will always be equal to DEFAULT_API_VERSION.
-            headers.insert(X_VERSION, DEFAULT_API_VERSION.parse().unwrap());
+            headers.insert(
+                ApiVersion::field_name(),
+                HeaderValue::from_static(ApiVersion::default_version()),
+            );
             let client = reqwest::Client::builder()
                 .cookie_store(true)
                 .default_headers(headers)

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -12,7 +12,6 @@ use utoipa::{
     Modify, OpenApi,
 };
 use utoipa_rapidoc::RapiDoc;
-use utoipa_swagger_ui::SwaggerUi;
 
 // This is the global definition of our OpenAPI spec. To be a part
 // of the rendered spec, a path and schema must be listed here.
@@ -69,8 +68,7 @@ pub fn define_routes(app_state: AppState) -> Router {
         .merge(organization_routes(app_state))
         .merge(session_routes())
         .merge(protected_routes())
-        // FIXME: protect the OpenAPI web UI endpoint we end up choosing to go with
-        .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+        // FIXME: protect the OpenAPI web UI
         // There is no need to create `RapiDoc::with_openapi` because the OpenApi is served
         // via SwaggerUi instead we only make rapidoc to point to the existing doc.
         .merge(RapiDoc::new("/api-docs/openapi.json").path("/rapidoc"))

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -12,7 +12,6 @@ use utoipa::{
     Modify, OpenApi,
 };
 use utoipa_rapidoc::RapiDoc;
-use utoipa_redoc::{Redoc, Servable};
 use utoipa_swagger_ui::SwaggerUi;
 
 // This is the global definition of our OpenAPI spec. To be a part
@@ -72,7 +71,6 @@ pub fn define_routes(app_state: AppState) -> Router {
         .merge(protected_routes())
         // FIXME: protect the OpenAPI web UI endpoint we end up choosing to go with
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
-        .merge(Redoc::with_url("/redoc", ApiDoc::openapi()))
         // There is no need to create `RapiDoc::with_openapi` because the OpenApi is served
         // via SwaggerUi instead we only make rapidoc to point to the existing doc.
         .merge(RapiDoc::new("/api-docs/openapi.json").path("/rapidoc"))

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -8,6 +8,8 @@ use entity_api::user::Backend;
 use tower_http::services::ServeDir;
 
 use utoipa::OpenApi;
+use utoipa_rapidoc::RapiDoc;
+use utoipa_redoc::{Redoc, Servable};
 use utoipa_swagger_ui::SwaggerUi;
 
 #[derive(OpenApi)]
@@ -38,6 +40,10 @@ pub fn define_routes(app_state: AppState) -> Router {
         .merge(protected_routes())
         // FIXME: protect this endpoint
         .merge(SwaggerUi::new("/swagger-ui").url("/api-docs/openapi.json", ApiDoc::openapi()))
+        .merge(Redoc::with_url("/redoc", ApiDoc::openapi()))
+        // There is no need to create `RapiDoc::with_openapi` because the OpenApi is served
+        // via SwaggerUi instead we only make rapidoc to point to the existing doc.
+        .merge(RapiDoc::new("/api-docs/openapi.json").path("/rapidoc"))
         .fallback_service(static_routes())
 }
 


### PR DESCRIPTION
## Description
This PR adds [OpenAPI](https://swagger.io/docs/specification/about/) documentation for the platform endpoints using the crate [utoipa](https://docs.rs/utoipa/latest/utoipa/index.html).


#### GitHub Issue: N/A

### Changes
* Adds OpenAPI documentation of all existing endpoints for the organization_controller and user_session_controller
* Moves the controllers out of empty structs and just as modules, otherwise they're unusable types for utoipa's ToSchema derive macro
* Exposes a web-based RAPIDoc UI to view the API documentation and try the API out

### Testing Strategy
1. `cargo run  -- -l TRACE -d postgres://refactor:password@localhost:5432/refactor_platform`
2. Point your web browser to http://localhost:4000/rapidoc
3. You'll see something like:

<img width="1569" alt="Screenshot 2024-03-24 at 18 47 14" src="https://github.com/Jim-Hodapp-Coaching/refactor-platform-rs/assets/3219120/830ef76a-6600-42b6-8a7e-e7bf0b365316">

3. Try logging in with the `/login` endpoint
4. Every other endpoint should be functional then...the set-cookie session cookie gets set and forwarded by the OpenAPI doc UI
5. Try logging out with the `/logout` endpoint
6. Every endpoint should fail then until you log in again

### Concerns
None
