### PR TITLE
Get organization by external

### DIFF
--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -50,16 +50,16 @@ pub async fn index(
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), organizations)))
 }
 
-/// GET a particular Organization specified by its primary key.
+/// GET a particular Organization specified by its external_id.
 #[utoipa::path(
     get,
-    path = "/organizations/{id}",
+    path = "/organizations/{external_id}",
     params(
         ApiVersion,
-        ("id" = i32, Path, description = "Organization id to retrieve")
+        ("external_id" = String, Path, description = "Organization external_id to retrieve")
     ),
     responses(
-        (status = 200, description = "Successfully retrieved a certain Organization by its id", body = [entity::organizations::Model]),
+        (status = 200, description = "Successfully retrieved a certain Organization by its external_id", body = [entity::organizations::Model]),
         (status = 401, description = "Unauthorized"),
         (status = 404, description = "Organization not found"),
         (status = 405, description = "Method not allowed")
@@ -71,12 +71,12 @@ pub async fn index(
 pub async fn read(
     CompareApiVersion(_v): CompareApiVersion,
     State(app_state): State<AppState>,
-    Path(id): Path<Id>,
+    Path(external_id): Path<String>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("GET Organization by id: {}", id);
+    debug!("GET Organization by external_id: {}", external_id);
 
     let organization: Option<organizations::Model> =
-        OrganizationApi::find_by_id(app_state.db_conn_ref(), id).await?;
+        OrganizationApi::find_by_external_id(app_state.db_conn_ref(), &external_id).await?;
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), organization)))
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -265,6 +265,9 @@ mod organization_endpoints_tests {
     async fn read_returns_expected_json_for_specified_organization() -> anyhow::Result<()> {
         let mut config = Config::default();
         let now = Utc::now();
+        let external_id = Uuid::new_v4();
+        let endpoint_path = format!("/organizations/{}", external_id);
+
         enable_test_logging(&mut config);
 
         let user = TestClientServer::get_user().expect("Creating a new test user failed");
@@ -274,7 +277,7 @@ mod organization_endpoints_tests {
             created_at: now.into(),
             updated_at: now.into(),
             logo: None,
-            external_id: Uuid::new_v4(),
+            external_id: external_id,
         };
 
         let organization_results = [vec![organization.clone()]];
@@ -301,7 +304,7 @@ mod organization_endpoints_tests {
 
         let response = test_client_server
             .client
-            .get(test_client_server.url("/organizations/1").unwrap())
+            .get(test_client_server.url(endpoint_path).unwrap())
             .send()
             .await?;
 
@@ -323,7 +326,7 @@ mod organization_endpoints_tests {
     // Purpose: adds multiple Organization instances to a mock DB and tests the API to successfully
     // retrieve all of them as expected and valid JSON without specifying any particular ID.
     #[tokio::test]
-    async fn read_returns_all_organizations() -> anyhow::Result<()> {
+    async fn index_returns_all_organizations() -> anyhow::Result<()> {
         let mut config = Config::default();
         let now = Utc::now();
         enable_test_logging(&mut config);


### PR DESCRIPTION
## Description
This PR updates the `GET /organizations/{id}` end point to query organizations by `external_id` (`GET /organizations/{external_id}`


#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_

### Changes
* Updates organizations read endpoint

### Testing Strategy
I was able to test this using rapidoc
<img width="881" alt="Screen Shot 2024-05-13 at 8 51 18 AM" src="https://github.com/Jim-Hodapp-Coaching/refactor-platform-rs/assets/14064042/a54b0c11-66a9-49f0-94f1-83d6f065cd61">
