### PR TITLE
Return a new coaching relationship struct identified by coaching_relationship_id

### DIFF
--- a/entity/src/coachees.rs
+++ b/entity/src/coachees.rs
@@ -1,0 +1,39 @@
+use crate::Id;
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, ToSchema, Serialize, Deserialize)]
+#[schema(as = entity::users::Model)] // OpenAPI schema
+#[sea_orm(schema_name = "refactor_platform", table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Id,
+    #[sea_orm(unique)]
+    pub email: String,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub display_name: Option<String>,
+    #[serde(skip)]
+    pub password: String,
+    pub github_username: Option<String>,
+    pub github_profile_url: Option<String>,
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
+    pub created_at: DateTimeWithTimeZone,
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
+    pub updated_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        has_many = "super::coaching_relationships::Entity",
+        from = "Column::Id",
+        to = "super::coaching_relationships::Column::CoacheeId",
+        on_update = "NoAction",
+        on_delete = "NoAction"
+    )]
+    CoachingRelationships,
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/entity/src/coaches.rs
+++ b/entity/src/coaches.rs
@@ -1,0 +1,39 @@
+use crate::Id;
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, ToSchema, Serialize, Deserialize)]
+#[schema(as = entity::users::Model)] // OpenAPI schema
+#[sea_orm(schema_name = "refactor_platform", table_name = "users")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: Id,
+    #[sea_orm(unique)]
+    pub email: String,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub display_name: Option<String>,
+    #[serde(skip)]
+    pub password: String,
+    pub github_username: Option<String>,
+    pub github_profile_url: Option<String>,
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
+    pub created_at: DateTimeWithTimeZone,
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
+    pub updated_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        has_many = "super::coaching_relationships::Entity",
+        from = "Column::Id",
+        to = "super::coaching_relationships::Column::CoachId",
+        on_update = "NoAction",
+        on_delete = "NoAction"
+    )]
+    CoachingRelationships,
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/entity/src/coaching_relationships.rs
+++ b/entity/src/coaching_relationships.rs
@@ -35,26 +35,38 @@ pub enum Relation {
     )]
     Organizations,
     #[sea_orm(
-        belongs_to = "super::users::Entity",
+        belongs_to = "super::coaches::Entity",
         from = "Column::CoachId",
-        to = "super::users::Column::Id",
+        to = "super::coaches::Column::Id",
         on_update = "NoAction",
         on_delete = "NoAction"
     )]
-    Users2,
+    Coaches,
     #[sea_orm(
-        belongs_to = "super::users::Entity",
+        belongs_to = "super::coachees::Entity",
         from = "Column::CoacheeId",
-        to = "super::users::Column::Id",
+        to = "super::coachees::Column::Id",
         on_update = "NoAction",
         on_delete = "NoAction"
     )]
-    Users1,
+    Coachees,
 }
 
 impl Related<super::organizations::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::Organizations.def()
+    }
+}
+
+impl Related<super::coaches::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Coaches.def()
+    }
+}
+
+impl Related<super::coachees::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Coachees.def()
     }
 }
 

--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -4,6 +4,8 @@ pub mod prelude;
 
 pub mod actions;
 pub mod agreements;
+pub mod coachees;
+pub mod coaches;
 pub mod coaching_relationships;
 pub mod coaching_sessions;
 pub mod notes;

--- a/entity/src/users.rs
+++ b/entity/src/users.rs
@@ -6,6 +6,7 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+// TODO: We should find a way to centralize the users/coaches/coachees types
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, ToSchema, Serialize, Deserialize)]
 #[schema(as = entity::users::Model)] // OpenAPI schema
 #[sea_orm(schema_name = "refactor_platform", table_name = "users")]

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -2,11 +2,9 @@ use super::error::{EntityApiErrorCode, Error};
 use crate::uuid_parse_str;
 use chrono::Utc;
 use entity::{
-    coaching_relationships,
-    coaching_relationships::{ActiveModel, Model},
-    Id,
+    coaching_relationships::{self, ActiveModel, Model}, users, Id
 };
-use sea_orm::{entity::prelude::*, Condition, DatabaseConnection, QuerySelect, QueryTrait, Set};
+use sea_orm::{entity::prelude::*, Condition, DatabaseConnection, JoinType, QuerySelect, QueryTrait, Set, sea_query::Alias};
 
 use log::*;
 
@@ -56,6 +54,32 @@ pub async fn find_by_organization(
     Ok(query.all(db).await?)
 }
 
+pub async fn find_by_organization_with_user_names(
+    db: &DatabaseConnection,
+    organization_id: Id,
+) -> Result<Vec<Model>, Error> {
+    let query = by_organization(coaching_relationships::Entity::find(), organization_id).await
+        .join_as(JoinType::Join, users::Relation::Coach.def().rev(), Alias::new("coach"))
+        // .join_as(JoinType::Join, coaching_relationships::Relation::Coach.def().rev(), Alias::new("coach"))
+        // .join_as(JoinType::Join, coaching_relationships::Relation::Coachee.def().rev(), Alias::new("coachee"))
+        .select_only();
+        // .column(coaching_relationships::Column::Id)
+        // .column(coaching_relationships::Column::OrganizationId)
+        // .column(coaching_relationships::Column::CoachId)
+        // .column(coaching_relationships::Column::CoacheeId)
+        // .column_as(crate::users::Column::FirstName, "coach_first_name")
+        // .column_as(crate::users::Column::LastName, "coach_last_name")
+        // .column_as(crate::users::Column::FirstName, "coachee_first_name")
+        // .column_as(crate::users::Column::LastName, "coachee_last_name");
+        // .into_query();
+        
+
+
+
+
+    Ok(query.all(db).await?)
+}
+
 pub async fn find_by(
     db: &DatabaseConnection,
     params: std::collections::HashMap<String, String>,
@@ -95,6 +119,45 @@ async fn by_organization(
     )
 }
 
+// A convenient combined struct that holds the results of looking up the Users associated
+// with the coach/coachee ids. This should be used as an implementation detail only.
+// struct CoachingRelationshipWithNames {
+//     pub id: Id,
+//     pub coach_id: Id,
+//     pub coachee_id: Id,
+//     pub coach_name: String,
+//     pub coachee_name: String,
+// }
+
+// impl From<Model> for CoachingRelationshipWithNames {
+//     fn from(model: Model) -> Self {
+//         coach = 
+//         Self {
+//             id: model.id,
+//             coach_id: model.coach_id,
+//             coachee_id: model.coachee_id,
+//             coach_name: ,
+//             coachee_name: "Coachee".to_string(),
+//         }
+//     }
+// }
+
+// serialize the CoachingRelationshipWithNames struct so that it can be used in the API
+// and appears to be a coaching_relationship JSON object.
+// impl Serialize for CoachingRelationshipWithNames {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//     where
+//         S: Serializer,
+//     {
+//         // 3 is the number of fields in the struct.
+//         let mut state = serializer.serialize_struct("Color", 3)?;
+//         state.serialize_field("", &self.r)?;
+//         state.serialize_field("g", &self.g)?;
+//         state.serialize_field("b", &self.b)?;
+//         state.end()
+//     }
+// }
+
 #[cfg(test)]
 // We need to gate seaORM's mock feature behind conditional compilation because
 // the feature removes the Clone trait implementation from seaORM's DatabaseConnection.
@@ -129,6 +192,25 @@ mod tests {
 
         let organization_id = Id::new_v4();
         let _ = find_by_organization(&db, organization_id).await;
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "coaching_relationships"."id", "coaching_relationships"."organization_id", "coaching_relationships"."coach_id", "coaching_relationships"."coachee_id", "coaching_relationships"."created_at", "coaching_relationships"."updated_at" FROM "refactor_platform"."coaching_relationships" WHERE "coaching_relationships"."organization_id" IN (SELECT "organizations"."id" FROM "refactor_platform"."organizations" WHERE "organizations"."id" = $1)"#,
+                [organization_id.clone().into()]
+            )]
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_by_organization_with_user_names_returns_all_records_by_organization_with_user_names() -> Result<(), Error> {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        let organization_id = Id::new_v4();
+        let _ = find_by_organization_with_user_names(&db, organization_id).await;
 
         assert_eq!(
             db.into_transaction_log(),

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -156,7 +156,6 @@ impl Serialize for CoachingRelationshipWithUserNames {
     where
         S: Serializer,
     {
-        // 3 is the number of fields in the struct.
         let mut state = serializer.serialize_struct("CoachingRelationship", 7)?;
         state.serialize_field("id", &self.id)?;
         state.serialize_field("coach_id", &self.coach_id)?;

--- a/web/src/controller/organization/coaching_relationship_controller.rs
+++ b/web/src/controller/organization/coaching_relationship_controller.rs
@@ -41,9 +41,11 @@ pub async fn index(
     Path(organization_id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET all CoachingRelationships");
-    let coaching_relationships =
-        CoachingRelationshipApi::find_by_organization(app_state.db_conn_ref(), organization_id)
-            .await?;
+    let coaching_relationships = CoachingRelationshipApi::find_by_organization_with_user_names(
+        app_state.db_conn_ref(),
+        organization_id,
+    )
+    .await?;
 
     debug!("Found CoachingRelationships: {:?}", coaching_relationships);
 


### PR DESCRIPTION
## Description

This PR adds adds `CoachingRelationshipApi::find_by_organization_with_user_names` for returning Coaching Relationship data enhanced with Coach and Coachee names.


#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_

### Changes
* Adds `Coaches` entity
* Adds `Coachees` entity
* Adds `CoachingRelationshipApi::find_by_organization_with_user_names`
* Adds `CoachingRelationshipWithUserNames` struct and `Serialize` implementation.

### Testing Strategy
Tested via rapidocs

<img width="956" alt="Screen Shot 2024-06-20 at 7 35 46 AM" src="https://github.com/Jim-Hodapp-Coaching/refactor-platform-rs/assets/14064042/765dd459-c1d6-45c9-9fba-651c1e47c60b">


