### PR TITLE
Add coaching sessions endpoint

### DIFF
--- a/docs/db/refactor_platform_rs.dbml
+++ b/docs/db/refactor_platform_rs.dbml
@@ -36,8 +36,8 @@ Table refactor_platform.users {
 Table refactor_platform.coaching_sessions {
   id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
   coaching_relationship_id uuid [not null, note: 'The coaching relationship (i.e. what coach & coachee under what organization) associated with this coaching session']
-  date timestamp [note: 'The date and time of a session']
-  timezone varchar [note: 'The baseline timezone used for the `date` field']
+  date timestamp [not null, note: 'The date and time of a session']
+  timezone varchar [not null, note: 'The baseline timezone used for the `date` field']
   created_at timestamptz [not null, default: `now()`]
   updated_at timestamptz [not null, default: `now()`, note: 'The last date and time fields were changed']
 }

--- a/entity/src/coaching_sessions.rs
+++ b/entity/src/coaching_sessions.rs
@@ -3,8 +3,9 @@
 use crate::Id;
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize, ToSchema)]
 #[sea_orm(schema_name = "refactor_platform", table_name = "coaching_sessions")]
 pub struct Model {
     #[sea_orm(primary_key)]

--- a/entity/src/coaching_sessions.rs
+++ b/entity/src/coaching_sessions.rs
@@ -11,8 +11,8 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: Id,
     pub coaching_relationship_id: Id,
-    pub date: Option<DateTime>,
-    pub timezone: Option<String>,
+    pub date: DateTime,
+    pub timezone: String,
     pub created_at: DateTimeWithTimeZone,
     pub updated_at: DateTimeWithTimeZone,
 }

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -1,0 +1,78 @@
+use super::error::{EntityApiErrorCode, Error};
+use crate::uuid_parse_str;
+use entity::{
+    coaching_sessions::{self, Entity, Model},
+    Id,
+};
+use sea_orm::{entity::prelude::*, DatabaseConnection};
+use std::collections::HashMap;
+
+pub async fn find_by_coaching_relationship(
+    db: &DatabaseConnection,
+    coaching_relationship_id: Id,
+) -> Result<Vec<Model>, Error> {
+    let query = by_coaching_relationship(Entity::find(), coaching_relationship_id).await;
+
+    Ok(query.all(db).await?)
+}
+
+pub async fn find_by(
+    db: &DatabaseConnection,
+    params: HashMap<String, String>,
+) -> Result<Vec<Model>, Error> {
+    let mut query = Entity::find();
+
+    for (key, value) in params {
+        match key.as_str() {
+            "coaching_relationship_id" => {
+                let coaching_relationship_id = uuid_parse_str(&value)?;
+                query = by_coaching_relationship(query, coaching_relationship_id).await;
+            }
+            _ => {
+                return Err(Error {
+                    inner: None,
+                    error_code: EntityApiErrorCode::InvalidQueryTerm,
+                });
+            }
+        }
+    }
+
+    Ok(query.all(db).await?)
+}
+
+async fn by_coaching_relationship(
+    query: Select<Entity>,
+    coaching_relationship_id: Id,
+) -> Select<Entity> {
+    query.filter(coaching_sessions::Column::CoachingRelationshipId.eq(coaching_relationship_id))
+}
+
+#[cfg(test)]
+// We need to gate seaORM's mock feature behind conditional compilation because
+// the feature removes the Clone trait implementation from seaORM's DatabaseConnection.
+// see https://github.com/SeaQL/sea-orm/issues/830
+#[cfg(feature = "mock")]
+mod tests {
+    use super::*;
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+
+    #[tokio::test]
+    async fn find_by_coaching_relationships_returns_all_records_associated_with_coaching_relationship(
+    ) -> Result<(), Error> {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        let coaching_relationship_id = Id::new_v4();
+        let _ = find_by_coaching_relationship(&db, coaching_relationship_id).await;
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "coaching_sessions"."id", "coaching_sessions"."coaching_relationship_id", "coaching_sessions"."date", "coaching_sessions"."timezone", "coaching_sessions"."created_at", "coaching_sessions"."updated_at" FROM "refactor_platform"."coaching_sessions" WHERE "coaching_sessions"."coaching_relationship_id" = $1"#,
+                [coaching_relationship_id.into()]
+            )]
+        );
+
+        Ok(())
+    }
+}

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -46,6 +46,7 @@ pub async fn find_by(
 mod tests {
     use super::*;
     use chrono::NaiveDate;
+    use entity::Id;
     use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
 
     #[tokio::test]
@@ -78,7 +79,7 @@ mod tests {
     async fn find_by_from_date_returns_all_records_after_date() -> Result<(), Error> {
         let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
         let mut query_params = HashMap::new();
-        let from_date = NaiveDate::from_ymd(2021, 1, 1);
+        let from_date = NaiveDate::from_ymd_opt(2021, 1, 1).unwrap();
 
         query_params.insert("from_date".to_owned(), from_date.to_string());
 
@@ -100,7 +101,7 @@ mod tests {
     async fn find_by_to_date_returns_all_records_before_date() -> Result<(), Error> {
         let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
         let mut query_params = HashMap::new();
-        let to_date = NaiveDate::from_ymd(2027, 1, 1);
+        let to_date = NaiveDate::from_ymd_opt(2027, 1, 1).unwrap();
 
         query_params.insert("to_date".to_owned(), to_date.to_string());
 

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -5,6 +5,7 @@ use sea_orm::{ActiveModelTrait, DatabaseConnection, Set};
 use entity::{coaching_relationships, organizations, users, Id};
 
 pub mod coaching_relationship;
+pub mod coaching_session;
 pub mod error;
 pub mod organization;
 pub mod user;

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -17,6 +17,13 @@ pub(crate) fn uuid_parse_str(uuid_str: &str) -> Result<Id, error::Error> {
     })
 }
 
+pub(crate) fn naive_date_parse_str(date_str: &str) -> Result<chrono::NaiveDate, error::Error> {
+    chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|_| error::Error {
+        inner: None,
+        error_code: error::EntityApiErrorCode::InvalidQueryTerm,
+    })
+}
+
 pub async fn seed_database(db: &DatabaseConnection) {
     let now = Utc::now();
 
@@ -162,6 +169,18 @@ pub async fn seed_database(db: &DatabaseConnection) {
 
     coaching_sessions::ActiveModel {
         coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
+        date: Set(now.naive_local().checked_sub_days(Days::new(28)).unwrap()),
+        timezone: Set("America/Chicago".to_owned()),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    }
+    .save(db)
+    .await
+    .unwrap();
+
+    coaching_sessions::ActiveModel {
+        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
         date: Set(now.naive_local().checked_sub_days(Days::new(7)).unwrap()),
         timezone: Set("America/Chicago".to_owned()),
         created_at: Set(now.into()),
@@ -174,7 +193,7 @@ pub async fn seed_database(db: &DatabaseConnection) {
 
     coaching_sessions::ActiveModel {
         coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
-        date: Set(now.naive_local().checked_add_days(Days::new(14)).unwrap()),
+        date: Set(now.naive_local().checked_sub_days(Days::new(14)).unwrap()),
         timezone: Set("America/Chicago".to_owned()),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
@@ -186,7 +205,19 @@ pub async fn seed_database(db: &DatabaseConnection) {
 
     coaching_sessions::ActiveModel {
         coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
-        date: Set(now.naive_local().checked_add_days(Days::new(21)).unwrap()),
+        date: Set(now.naive_local().checked_sub_days(Days::new(21)).unwrap()),
+        timezone: Set("America/Chicago".to_owned()),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    }
+    .save(db)
+    .await
+    .unwrap();
+
+    coaching_sessions::ActiveModel {
+        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
+        date: Set(now.naive_local().checked_sub_days(Days::new(28)).unwrap()),
         timezone: Set("America/Chicago".to_owned()),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
@@ -216,6 +247,20 @@ mod tests {
     async fn uuid_parse_str_returns_error_for_invalid_uuid() {
         let uuid_str = "invalid";
         let result = uuid_parse_str(uuid_str);
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn naive_date_parse_str_parses_valid_date() {
+        let date_str = "2021-08-01";
+        let date = naive_date_parse_str(date_str).unwrap();
+        assert_eq!(date.to_string(), date_str);
+    }
+
+    #[tokio::test]
+    async fn naive_date_parse_str_returns_error_for_invalid_date() {
+        let date_str = "invalid";
+        let result = naive_date_parse_str(date_str);
         assert!(result.is_err());
     }
 }

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -1,8 +1,8 @@
-use chrono::Utc;
+use chrono::{Days, Utc};
 use password_auth::generate_hash;
 use sea_orm::{ActiveModelTrait, DatabaseConnection, Set};
 
-use entity::{coaching_relationships, organizations, users, Id};
+use entity::{coaching_relationships, coaching_sessions, organizations, users, Id};
 
 pub mod coaching_relationship;
 pub mod coaching_session;
@@ -88,7 +88,7 @@ pub async fn seed_database(db: &DatabaseConnection) {
     .await
     .unwrap();
 
-    coaching_relationships::ActiveModel {
+    let jim_caleb_coaching_relationship = coaching_relationships::ActiveModel {
         coach_id: Set(jim_hodapp.id.clone().unwrap()),
         coachee_id: Set(caleb_bourg.id.clone().unwrap()),
         organization_id: Set(jim_hodapp_coaching.id.unwrap()),
@@ -104,6 +104,90 @@ pub async fn seed_database(db: &DatabaseConnection) {
         coach_id: Set(jim_hodapp.id.clone().unwrap()),
         coachee_id: Set(other_user.id.clone().unwrap()),
         organization_id: Set(jim_hodapp_other_org.id.unwrap()),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    }
+    .save(db)
+    .await
+    .unwrap();
+
+    coaching_sessions::ActiveModel {
+        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
+        date: Set(now.naive_local()),
+        timezone: Set("America/Chicago".to_owned()),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    }
+    .save(db)
+    .await
+    .unwrap();
+
+    coaching_sessions::ActiveModel {
+        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
+        date: Set(now.naive_local().checked_add_days(Days::new(7)).unwrap()),
+        timezone: Set("America/Chicago".to_owned()),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    }
+    .save(db)
+    .await
+    .unwrap();
+
+    coaching_sessions::ActiveModel {
+        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
+        date: Set(now.naive_local().checked_add_days(Days::new(14)).unwrap()),
+        timezone: Set("America/Chicago".to_owned()),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    }
+    .save(db)
+    .await
+    .unwrap();
+
+    coaching_sessions::ActiveModel {
+        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
+        date: Set(now.naive_local().checked_add_days(Days::new(21)).unwrap()),
+        timezone: Set("America/Chicago".to_owned()),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    }
+    .save(db)
+    .await
+    .unwrap();
+
+    coaching_sessions::ActiveModel {
+        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
+        date: Set(now.naive_local().checked_sub_days(Days::new(7)).unwrap()),
+        timezone: Set("America/Chicago".to_owned()),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    }
+    .save(db)
+    .await
+    .unwrap();
+
+    coaching_sessions::ActiveModel {
+        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
+        date: Set(now.naive_local().checked_add_days(Days::new(14)).unwrap()),
+        timezone: Set("America/Chicago".to_owned()),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    }
+    .save(db)
+    .await
+    .unwrap();
+
+    coaching_sessions::ActiveModel {
+        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
+        date: Set(now.naive_local().checked_add_days(Days::new(21)).unwrap()),
+        timezone: Set("America/Chicago".to_owned()),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
         ..Default::default()

--- a/migration/src/refactor_platform_rs.sql
+++ b/migration/src/refactor_platform_rs.sql
@@ -1,6 +1,6 @@
 -- SQL dump generated using DBML (dbml-lang.org)
 -- Database: PostgreSQL
--- Generated at: 2024-05-21T12:05:17.574Z
+-- Generated at: 2024-06-28T21:45:29.597Z
 
 
 CREATE TABLE "refactor_platform"."organizations" (
@@ -36,8 +36,8 @@ CREATE TABLE "refactor_platform"."users" (
 CREATE TABLE "refactor_platform"."coaching_sessions" (
   "id" uuid UNIQUE PRIMARY KEY NOT NULL DEFAULT (gen_random_uuid()),
   "coaching_relationship_id" uuid NOT NULL,
-  "date" timestamp,
-  "timezone" varchar,
+  "date" timestamp NOT NULL,
+  "timezone" varchar NOT NULL,
   "created_at" timestamptz NOT NULL DEFAULT (now()),
   "updated_at" timestamptz NOT NULL DEFAULT (now())
 );

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -1,0 +1,51 @@
+use crate::controller::ApiResponse;
+use crate::extractors::{
+    authenticated_user::AuthenticatedUser, compare_api_version::CompareApiVersion,
+};
+use crate::{AppState, Error};
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use entity_api::coaching_session as CoachingSessionApi;
+use service::config::ApiVersion;
+use std::collections::HashMap;
+
+use log::*;
+
+#[utoipa::path(
+    get,
+    path = "/coaching_sessions",
+    params(
+        ApiVersion,
+        ("coaching_relationship_id" = Option<Id>, Query, description = "Filter by coaching_relationship_id")
+    ),
+    responses(
+        (status = 200, description = "Successfully retrieved all Coaching Sessions", body = [entity::coaching_sessions::Model]),
+        (status = 401, description = "Unauthorized"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn index(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    // TODO: create a new Extractor to authorize the user to access
+    // the data requested
+    State(app_state): State<AppState>,
+    Query(params): Query<HashMap<String, String>>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("GET all Coaching Sessions");
+    debug!("Filter Params: {:?}", params);
+
+    let coaching_sessions = CoachingSessionApi::find_by(app_state.db_conn_ref(), params).await?;
+
+    debug!("Found Coaching Sessions: {:?}", coaching_sessions);
+
+    Ok(Json(ApiResponse::new(
+        StatusCode::OK.into(),
+        coaching_sessions,
+    )))
+}

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -18,7 +18,9 @@ use log::*;
     path = "/coaching_sessions",
     params(
         ApiVersion,
-        ("coaching_relationship_id" = Option<Id>, Query, description = "Filter by coaching_relationship_id")
+        ("coaching_relationship_id" = Option<Id>, Query, description = "Filter by coaching_relationship_id"),
+        ("from_date" = Option<NaiveDate>, Query, description = "Filter by from_date"),
+        ("to_date" = Option<NaiveDate>, Query, description = "Filter by to_date")
     ),
     responses(
         (status = 200, description = "Successfully retrieved all Coaching Sessions", body = [entity::coaching_sessions::Model]),

--- a/web/src/controller/mod.rs
+++ b/web/src/controller/mod.rs
@@ -1,5 +1,6 @@
 use serde::Serialize;
 
+pub(crate) mod coaching_session_controller;
 pub(crate) mod organization;
 pub(crate) mod organization_controller;
 pub(crate) mod user_session_controller;


### PR DESCRIPTION
## Description
This PR adds the ability to fetch coaching sessions by:
- `coaching_relationship_id`
- `from_date`
- `to_date`


#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_

### Changes
* Adds `GET /coaching_sessions` endpoint
* Adds `coaching_session::find_by` with the ability to filter by the above query params
* Adds seeds for `coaching_sessions` records
* Adds rapidoc specification for `GET /coaching_sessions`

### Testing Strategy
Tested locally using rapidoc
<img width="1052" alt="Screen Shot 2024-07-02 at 8 58 50 AM" src="https://github.com/Jim-Hodapp-Coaching/refactor-platform-rs/assets/14064042/32c90c3d-7c2f-4b1b-b8c6-a44d97b96101">



### Concerns
I may consider moving the `coaching_relationship_id` into an explicit path parameter (`GET /coaching_relationships/:coaching_relationship_id/coaching_sessions`) so that this endpoint will require scoping the list of `coaching_sessions` to a specific `coaching_relationship_id`.  I think we can brainstorm on this when we implement an authorizations strategy.