### PR TITLE
Add basic infrastructure for notes API

### DIFF
--- a/entity/src/notes.rs
+++ b/entity/src/notes.rs
@@ -3,8 +3,9 @@
 use crate::Id;
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
 
-#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize, ToSchema)]
 #[sea_orm(schema_name = "refactor_platform", table_name = "notes")]
 pub struct Model {
     #[sea_orm(primary_key)]

--- a/entity/src/notes.rs
+++ b/entity/src/notes.rs
@@ -9,16 +9,15 @@ use utoipa::ToSchema;
 #[schema(as = entity::notes::Model)]
 #[sea_orm(schema_name = "refactor_platform", table_name = "notes")]
 pub struct Model {
-    #[serde(skip)]
+    #[serde(skip_deserializing)]
     #[sea_orm(primary_key)]
     pub id: Id,
     pub coaching_session_id: Id,
     pub body: Option<String>,
     pub user_id: Id,
-    // look into only skipping on deserialize
-    #[serde(skip)]
+    #[serde(skip_deserializing)]
     pub created_at: DateTimeWithTimeZone,
-    #[serde(skip)]
+    #[serde(skip_deserializing)]
     pub updated_at: DateTimeWithTimeZone,
 }
 

--- a/entity/src/notes.rs
+++ b/entity/src/notes.rs
@@ -6,14 +6,19 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize, ToSchema)]
+#[schema(as = entity::notes::Model)]
 #[sea_orm(schema_name = "refactor_platform", table_name = "notes")]
 pub struct Model {
+    #[serde(skip)]
     #[sea_orm(primary_key)]
     pub id: Id,
     pub coaching_session_id: Id,
     pub body: Option<String>,
     pub user_id: Id,
+    // look into only skipping on deserialize
+    #[serde(skip)]
     pub created_at: DateTimeWithTimeZone,
+    #[serde(skip)]
     pub updated_at: DateTimeWithTimeZone,
 }
 

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -7,6 +7,7 @@ use entity::{coaching_relationships, coaching_sessions, organizations, users, Id
 pub mod coaching_relationship;
 pub mod coaching_session;
 pub mod error;
+pub mod note;
 pub mod organization;
 pub mod user;
 

--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -1,0 +1,57 @@
+use super::error::Error;
+use entity::notes::{ActiveModel, Model};
+use sea_orm::{entity::prelude::*, DatabaseConnection, Set, TryIntoModel};
+
+use log::*;
+
+pub async fn create(db: &DatabaseConnection, note_model: Model) -> Result<Model, Error> {
+    debug!("New Note Model to be inserted: {:?}", note_model);
+
+    let now = chrono::Utc::now();
+
+    let note_active_model: ActiveModel = ActiveModel {
+        coaching_session_id: Set(note_model.coaching_session_id),
+        body: Set(note_model.body),
+        user_id: Set(note_model.user_id),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    };
+
+    Ok(note_active_model.save(db).await?.try_into_model()?)
+}
+
+#[cfg(test)]
+// We need to gate seaORM's mock feature behind conditional compilation because
+// the feature removes the Clone trait implementation from seaORM's DatabaseConnection.
+// see https://github.com/SeaQL/sea-orm/issues/830
+#[cfg(feature = "mock")]
+mod tests {
+    use super::*;
+    use entity::{notes::Model, Id};
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    #[tokio::test]
+    async fn create_returns_a_new_note_model() -> Result<(), Error> {
+        let now = chrono::Utc::now();
+
+        let note_model = Model {
+            id: Id::new_v4(),
+            coaching_session_id: Id::new_v4(),
+            body: Some("This is a note".to_owned()),
+            user_id: Id::new_v4(),
+            created_at: now.into(),
+            updated_at: now.into(),
+        };
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![note_model.clone()]])
+            .into_connection();
+
+        let note = create(&db, note_model.clone().into()).await?;
+
+        assert_eq!(note.id, note_model.id);
+
+        Ok(())
+    }
+}

--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -1,6 +1,8 @@
-use super::error::Error;
-use entity::notes::{ActiveModel, Model};
+use super::error::{EntityApiErrorCode, Error};
+use crate::uuid_parse_str;
+use entity::notes::{self, ActiveModel, Entity, Model};
 use sea_orm::{entity::prelude::*, DatabaseConnection, Set, TryIntoModel};
+use std::collections::HashMap;
 
 use log::*;
 
@@ -21,6 +23,31 @@ pub async fn create(db: &DatabaseConnection, note_model: Model) -> Result<Model,
     Ok(note_active_model.save(db).await?.try_into_model()?)
 }
 
+pub async fn find_by(
+    db: &DatabaseConnection,
+    query_params: HashMap<String, String>,
+) -> Result<Vec<Model>, Error> {
+    let mut query = Entity::find();
+
+    for (key, value) in query_params {
+        match key.as_str() {
+            "coaching_session_id" => {
+                let coaching_session_id = uuid_parse_str(&value)?;
+
+                query = query.filter(notes::Column::CoachingSessionId.eq(coaching_session_id));
+            }
+            _ => {
+                return Err(Error {
+                    inner: None,
+                    error_code: EntityApiErrorCode::InvalidQueryTerm,
+                });
+            }
+        }
+    }
+
+    Ok(query.all(db).await?)
+}
+
 #[cfg(test)]
 // We need to gate seaORM's mock feature behind conditional compilation because
 // the feature removes the Clone trait implementation from seaORM's DatabaseConnection.
@@ -29,7 +56,7 @@ pub async fn create(db: &DatabaseConnection, note_model: Model) -> Result<Model,
 mod tests {
     use super::*;
     use entity::{notes::Model, Id};
-    use sea_orm::{DatabaseBackend, MockDatabase};
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
 
     #[tokio::test]
     async fn create_returns_a_new_note_model() -> Result<(), Error> {
@@ -51,6 +78,31 @@ mod tests {
         let note = create(&db, note_model.clone().into()).await?;
 
         assert_eq!(note.id, note_model.id);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn find_by_returns_all_notes_associated_with_coaching_session() -> Result<(), Error> {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+        let mut query_params = HashMap::new();
+        let coaching_session_id = Id::new_v4();
+
+        query_params.insert(
+            "coaching_session_id".to_owned(),
+            coaching_session_id.to_string(),
+        );
+
+        let _ = find_by(&db, query_params).await;
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "notes"."id", "notes"."coaching_session_id", "notes"."body", "notes"."user_id", "notes"."created_at", "notes"."updated_at" FROM "refactor_platform"."notes" WHERE "notes"."coaching_session_id" = $1"#,
+                [coaching_session_id.into()]
+            )]
+        );
 
         Ok(())
     }

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -55,7 +55,7 @@ pub struct Config {
     #[arg(
         short,
         long,
-        default_value_t = LevelFilter::Warn,
+        default_value_t = LevelFilter::Debug,
         value_parser = clap::builder::PossibleValuesParser::new(["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"])
             .map(|s| s.parse::<LevelFilter>().unwrap()),
         )]

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -55,7 +55,7 @@ pub struct Config {
     #[arg(
         short,
         long,
-        default_value_t = LevelFilter::Debug,
+        default_value_t = LevelFilter::Warn,
         value_parser = clap::builder::PossibleValuesParser::new(["OFF", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"])
             .map(|s| s.parse::<LevelFilter>().unwrap()),
         )]

--- a/web/src/controller/mod.rs
+++ b/web/src/controller/mod.rs
@@ -1,6 +1,7 @@
 use serde::Serialize;
 
 pub(crate) mod coaching_session_controller;
+pub(crate) mod note_controller;
 pub(crate) mod organization;
 pub(crate) mod organization_controller;
 pub(crate) mod user_session_controller;

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -6,8 +6,9 @@ use crate::{AppState, Error};
 use axum::extract::State;
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
-use axum::{Form, Json};
+use axum::Json;
 use entity_api::note as NoteApi;
+use entity::notes::Model;
 use service::config::ApiVersion;
 
 use log::*;
@@ -16,6 +17,7 @@ use log::*;
 #[utoipa::path(
     post,
     path = "/notes",
+    request_body(content = entity_api::notes::Model, content_type = "application/json"),
     params(ApiVersion),
     responses(
         (status = 201, description = "Successfully Created a New Note", body = [entity::notes::Model]),
@@ -28,14 +30,13 @@ use log::*;
     )
 )]
 
-/// POST Create a New Note
 pub async fn create(
     CompareApiVersion(_v): CompareApiVersion,
     AuthenticatedUser(_user): AuthenticatedUser,
     // TODO: create a new Extractor to authorize the user to access
     // the data requested
     State(app_state): State<AppState>,
-    Json(note_model): Json<entity::notes::Model>,
+    Json(note_model): Json<Model>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("POST Create a New Note with from: {:?}", note_model);
 

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -1,0 +1,47 @@
+use crate::controller::ApiResponse;
+use crate::extractors::{
+    authenticated_user::AuthenticatedUser, compare_api_version::CompareApiVersion,
+};
+use crate::{AppState, Error};
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::{Form, Json};
+use entity_api::note as NoteApi;
+use service::config::ApiVersion;
+
+use log::*;
+
+/// POST create a new Note
+#[utoipa::path(
+    post,
+    path = "/notes",
+    params(ApiVersion),
+    responses(
+        (status = 201, description = "Successfully Created a New Note", body = [entity::notes::Model]),
+        (status= 422, description = "Unprocessable Entity"),
+        (status = 401, description = "Unauthorized"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+
+/// POST Create a New Note
+pub async fn create(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    // TODO: create a new Extractor to authorize the user to access
+    // the data requested
+    State(app_state): State<AppState>,
+    Json(note_model): Json<entity::notes::Model>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("POST Create a New Note with from: {:?}", note_model);
+
+    let note = NoteApi::create(app_state.db_conn_ref(), note_model).await?;
+
+    debug!("New Note: {:?}", note);
+
+    Ok(Json(ApiResponse::new(StatusCode::CREATED.into(), note)))
+}

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -27,6 +27,7 @@ use utoipa_rapidoc::RapiDoc;
         ),
         paths(
             note_controller::create,
+            note_controller::index,
             organization_controller::index,
             organization_controller::read,
             organization_controller::create,
@@ -98,6 +99,7 @@ fn organization_coaching_relationship_routes(app_state: AppState) -> Router {
 fn note_routes(app_state: AppState) -> Router {
     Router::new()
         .route("/notes", post(note_controller::create))
+        .route("/notes", get(note_controller::index))
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -8,7 +8,8 @@ use entity_api::user::Backend;
 use tower_http::services::ServeDir;
 
 use crate::controller::{
-    coaching_session_controller, organization, organization_controller, user_session_controller,
+    coaching_session_controller, note_controller, organization, organization_controller,
+    user_session_controller,
 };
 
 use utoipa::{
@@ -25,6 +26,7 @@ use utoipa_rapidoc::RapiDoc;
             title = "Refactor Platform API"
         ),
         paths(
+            note_controller::create,
             organization_controller::index,
             organization_controller::read,
             organization_controller::create,
@@ -37,6 +39,7 @@ use utoipa_rapidoc::RapiDoc;
         ),
         components(
             schemas(
+                entity::notes::Model,
                 entity::organizations::Model,
                 entity::users::Model,
                 entity::coaching_relationships::Model,
@@ -72,6 +75,7 @@ impl Modify for SecurityAddon {
 pub fn define_routes(app_state: AppState) -> Router {
     Router::new()
         .merge(organization_routes(app_state.clone()))
+        .merge(note_routes(app_state.clone()))
         .merge(organization_coaching_relationship_routes(app_state.clone()))
         .merge(session_routes())
         .merge(protected_routes())
@@ -87,6 +91,13 @@ fn organization_coaching_relationship_routes(app_state: AppState) -> Router {
             "/organizations/:organization_id/coaching_relationships",
             get(organization::coaching_relationship_controller::index),
         )
+        .route_layer(login_required!(Backend, login_url = "/login"))
+        .with_state(app_state)
+}
+
+fn note_routes(app_state: AppState) -> Router {
+    Router::new()
+        .route("/notes", post(note_controller::create))
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)
 }


### PR DESCRIPTION
## Description

Adds endpoints and Entity APIs for creating and indexing `notes` records.


#### GitHub Issue: [Closes] #53

### Changes
* Adds `GET /notes` and the ability to filter by `coaching_session_id`
* Adds `POST /notes` for creating new notes

### Testing Strategy

Tested using Rapidoc

<img width="976" alt="Screen Shot 2024-07-17 at 7 01 11 AM" src="https://github.com/user-attachments/assets/0fd09ff2-b951-43cc-b00d-d26797af5dc4">

