### PR TITLE
Add the ability to update note records

### DIFF
--- a/entity/src/notes.rs
+++ b/entity/src/notes.rs
@@ -12,8 +12,10 @@ pub struct Model {
     #[serde(skip_deserializing)]
     #[sea_orm(primary_key)]
     pub id: Id,
+    #[serde(skip_deserializing)]
     pub coaching_session_id: Id,
     pub body: Option<String>,
+    #[serde(skip_deserializing)]
     pub user_id: Id,
     #[serde(skip_deserializing)]
     pub created_at: DateTimeWithTimeZone,

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -3,11 +3,11 @@ use crate::extractors::{
     authenticated_user::AuthenticatedUser, compare_api_version::CompareApiVersion,
 };
 use crate::{AppState, Error};
-use axum::extract::{Query, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use entity::notes::Model;
+use entity::{notes::Model, Id};
 use entity_api::note as NoteApi;
 use service::config::ApiVersion;
 use std::collections::HashMap;
@@ -46,6 +46,41 @@ pub async fn create(
     debug!("New Note: {:?}", note);
 
     Ok(Json(ApiResponse::new(StatusCode::CREATED.into(), note)))
+}
+
+#[utoipa::path(
+    put,
+    path = "/notes/{id}",
+    request_body(content = entity_api::notes::Model, content_type = "application/json"),
+    params(
+        ApiVersion,
+        ("id" = Id, Path, description = "Id of note to update"),
+    ),
+    responses(
+        (status = 200, description = "Successfully Updated Note", body = [entity::notes::Model]),
+        (status = 401, description = "Unauthorized"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn update(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    // TODO: create a new Extractor to authorize the user to access
+    // the data requested
+    State(app_state): State<AppState>,
+    Path(id): Path<Id>,
+    Json(note_model): Json<Model>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("PUT Update Note with id: {}", id);
+
+    let note = NoteApi::update(app_state.db_conn_ref(), id, note_model).await?;
+
+    debug!("Updated Note: {:?}", note);
+
+    Ok(Json(ApiResponse::new(StatusCode::OK.into(), note)))
 }
 
 #[utoipa::path(

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -18,8 +18,8 @@ use log::*;
 #[utoipa::path(
     post,
     path = "/notes",
-    request_body(content = entity_api::notes::Model, content_type = "application/json"),
     params(ApiVersion),
+    request_body = entity::notes::Model,
     responses(
         (status = 201, description = "Successfully Created a New Note", body = [entity::notes::Model]),
         (status= 422, description = "Unprocessable Entity"),
@@ -51,11 +51,11 @@ pub async fn create(
 #[utoipa::path(
     put,
     path = "/notes/{id}",
-    request_body(content = entity_api::notes::Model, content_type = "application/json"),
     params(
         ApiVersion,
         ("id" = Id, Path, description = "Id of note to update"),
     ),
+    request_body = entity::notes::Model,
     responses(
         (status = 200, description = "Successfully Updated Note", body = [entity::notes::Model]),
         (status = 401, description = "Unauthorized"),

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -27,6 +27,7 @@ use utoipa_rapidoc::RapiDoc;
         ),
         paths(
             note_controller::create,
+            note_controller::update,
             note_controller::index,
             organization_controller::index,
             organization_controller::read,
@@ -99,6 +100,7 @@ fn organization_coaching_relationship_routes(app_state: AppState) -> Router {
 fn note_routes(app_state: AppState) -> Router {
     Router::new()
         .route("/notes", post(note_controller::create))
+        .route("/notes/:id", put(note_controller::update))
         .route("/notes", get(note_controller::index))
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)


### PR DESCRIPTION
## Description

Adds a `PUT /notes/:id` endpoint for updating existing notes records


#### GitHub Issue: none

### Changes
* Adds `entity_api::note::update`
* Adds new endpoint


### Testing Strategy

Tested using rapidoc
<img width="643" alt="Screen Shot 2024-07-22 at 8 30 24 AM" src="https://github.com/user-attachments/assets/0022f2ad-139e-4f65-a871-31ff79bccccb">
<img width="835" alt="Screen Shot 2024-07-22 at 8 30 20 AM" src="https://github.com/user-attachments/assets/5f045600-10eb-45a5-b2b5-ac8a1ab81fe7">
