### PR TITLE
Set coaching_session_id and user_id for the POST/PUT Notes endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,9 +630,9 @@ checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2794,18 +2794,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.195"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63261df402c67811e9ac6def069e4786148c4563f4b50fd4bf30aa370d626b02"
+checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.195"
+version = "1.0.204"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fe8f8603d81ba86327b23a2e9cdf49e1255fb94a4c5f297f6ee0547178ea2c"
+checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3377,9 +3377,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.34"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8248b6521bb14bc45b4067159b9b6ad792e2d6d754d6c41fb50e29fefe38749"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
@@ -3400,9 +3400,9 @@ checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.17"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba3a3ef41e6672a2f0f001392bb5dcd3ff0a9992d618ca761a11c3121547774"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
  "num-conv",
  "time-core",

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 axum-login = "0.12.0"
-chrono = { version = "0.4.34", features = ["serde"] }
+chrono = { version = "0.4.38", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }
 uuid = "1.7.0"

--- a/entity/src/notes.rs
+++ b/entity/src/notes.rs
@@ -12,10 +12,8 @@ pub struct Model {
     #[serde(skip_deserializing)]
     #[sea_orm(primary_key)]
     pub id: Id,
-    #[serde(skip_deserializing)]
     pub coaching_session_id: Id,
     pub body: Option<String>,
-    #[serde(skip_deserializing)]
     pub user_id: Id,
     #[serde(skip_deserializing)]
     pub created_at: DateTimeWithTimeZone,

--- a/entity_api/Cargo.toml
+++ b/entity_api/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-chrono = { version = "0.4.34", features = ["serde"] }
+chrono = { version = "0.4.38", features = ["serde"] }
 entity = { path = "../entity" }
 service = { path = "../service" }
 serde_json = "1.0.107"

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -38,6 +38,6 @@ mock = ["sea-orm/mock"]
 
 [dev-dependencies]
 anyhow = "1.0.76"
-chrono = { version = "0.4.34", features = ["serde"] }
+chrono = { version = "0.4.38", features = ["serde"] }
 password-auth = "1.0.0"
 reqwest = { version = "0.11.23", features = ["json", "cookies"] }

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -39,7 +39,7 @@ pub async fn create(
     State(app_state): State<AppState>,
     Json(note_model): Json<Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("POST Create a New Note with from: {:?}", note_model);
+    debug!("POST Create a New Note from: {:?}", note_model);
 
     let note = NoteApi::create(app_state.db_conn_ref(), note_model).await?;
 


### PR DESCRIPTION
## Description
Make sure that the POST/PUT endpoints for creating/updating a Note are able to take in, deserialize and set the required coaching_session_id and user_id fields, due to these being required foreign keys.


#### GitHub Issue: None

### Changes
* Set coaching_session_id and user_id for the POST/PUT Notes endpoints

### Testing Strategy
Try creating a new note using the RAPIdoc interface at http://localhost:4000/rapidoc#post-/notes


### Concerns
None
