### PR TITLE
Retrieve a Note by its id

### DIFF
--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -57,6 +57,32 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
     }
 }
 
+pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>, Error> {
+    match Entity::find_by_id(id).one(db).await {
+        Ok(Some(note)) => {
+            debug!("Note found: {:?}", note);
+
+            Ok(Some(note))
+        }
+        Ok(None) => {
+            debug!("Note with id {} not found", id);
+
+            Err(Error {
+                inner: None,
+                error_code: EntityApiErrorCode::RecordNotFound,
+            })
+        }
+        Err(err) => {
+            debug!("Note with id {} not found and returned error {}", id, err);
+            Err(Error {
+                inner: None,
+                error_code: EntityApiErrorCode::RecordNotFound,
+            })
+            
+        }
+    }
+}
+
 pub async fn find_by(
     db: &DatabaseConnection,
     query_params: HashMap<String, String>,

--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -47,7 +47,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
             Ok(active_model.update(db).await?.try_into_model()?)
         }
         None => {
-            debug!("Note with id {} not found", id);
+            error!("Note with id {} not found", id);
 
             Err(Error {
                 inner: None,
@@ -65,7 +65,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
             Ok(Some(note))
         }
         Ok(None) => {
-            debug!("Note with id {} not found", id);
+            error!("Note with id {} not found", id);
 
             Err(Error {
                 inner: None,
@@ -73,7 +73,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
             })
         }
         Err(err) => {
-            debug!("Note with id {} not found and returned error {}", id, err);
+            error!("Note with id {} not found and returned error {}", id, err);
             Err(Error {
                 inner: None,
                 error_code: EntityApiErrorCode::RecordNotFound,

--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -78,7 +78,6 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
                 inner: None,
                 error_code: EntityApiErrorCode::RecordNotFound,
             })
-            
         }
     }
 }

--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -104,7 +104,27 @@ pub async fn find_by(
         }
     }
 
-    Ok(query.all(db).await?)
+    match query.all(db).await {
+        Ok(notes) => {
+            debug!("Note found: {:?}", notes);
+
+            if !notes.is_empty() {
+                Ok(notes)
+            } else {
+                Err(Error {
+                    inner: None,
+                    error_code: EntityApiErrorCode::RecordNotFound,
+                })
+            }
+        }
+        Err(err) => {
+            error!("Error encountered retrieving all notes {}", err);
+            Err(Error {
+                inner: None,
+                error_code: EntityApiErrorCode::SystemError,
+            })
+        }
+    }
 }
 
 #[cfg(test)]

--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -104,27 +104,7 @@ pub async fn find_by(
         }
     }
 
-    match query.all(db).await {
-        Ok(notes) => {
-            debug!("Note found: {:?}", notes);
-
-            if !notes.is_empty() {
-                Ok(notes)
-            } else {
-                Err(Error {
-                    inner: None,
-                    error_code: EntityApiErrorCode::RecordNotFound,
-                })
-            }
-        }
-        Err(err) => {
-            error!("Error encountered retrieving all notes {}", err);
-            Err(Error {
-                inner: None,
-                error_code: EntityApiErrorCode::SystemError,
-            })
-        }
-    }
+    Ok(query.all(db).await?)
 }
 
 #[cfg(test)]

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -130,6 +130,7 @@ pub async fn index(
     ),
     responses(
         (status = 200, description = "Successfully retrieved a certain Note by its id", body = [entity::notes::Model]),
+        (status = 204, description = "No content"),
         (status = 401, description = "Unauthorized"),
         (status = 404, description = "Note not found"),
         (status = 405, description = "Method not allowed")
@@ -145,7 +146,8 @@ pub async fn read(
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET Organization by id: {}", id);
 
-    let note: Option<notes::Model> = NoteApi::find_by_id(app_state.db_conn_ref(), id).await?;
+    let note: Option<notes::Model> =
+        NoteApi::find_by_id(app_state.db_conn_ref(), id).await?;
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), note)))
 }

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -110,14 +110,11 @@ pub async fn index(
     debug!("GET all Notes");
     debug!("Filter Params: {:?}", params);
 
-    let coaching_sessions = NoteApi::find_by(app_state.db_conn_ref(), params).await?;
+    let notes = NoteApi::find_by(app_state.db_conn_ref(), params).await?;
 
-    debug!("Found Notes: {:?}", coaching_sessions);
+    debug!("Found Notes: {:?}", notes);
 
-    Ok(Json(ApiResponse::new(
-        StatusCode::OK.into(),
-        coaching_sessions,
-    )))
+    Ok(Json(ApiResponse::new(StatusCode::OK.into(), notes)))
 }
 
 /// GET a particular Note specified by its id.

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -146,8 +146,7 @@ pub async fn read(
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET Organization by id: {}", id);
 
-    let note: Option<notes::Model> =
-        NoteApi::find_by_id(app_state.db_conn_ref(), id).await?;
+    let note: Option<notes::Model> = NoteApi::find_by_id(app_state.db_conn_ref(), id).await?;
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), note)))
 }

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -7,7 +7,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use entity::{notes::Model, Id};
+use entity::{notes, Id};
 use entity_api::note as NoteApi;
 use service::config::ApiVersion;
 use std::collections::HashMap;
@@ -37,7 +37,7 @@ pub async fn create(
     // TODO: create a new Extractor to authorize the user to access
     // the data requested
     State(app_state): State<AppState>,
-    Json(note_model): Json<Model>,
+    Json(note_model): Json<notes::Model>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("POST Create a New Note from: {:?}", note_model);
 
@@ -72,7 +72,7 @@ pub async fn update(
     // the data requested
     State(app_state): State<AppState>,
     Path(id): Path<Id>,
-    Json(note_model): Json<Model>,
+    Json(note_model): Json<notes::Model>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("PUT Update Note with id: {}", id);
 
@@ -118,4 +118,35 @@ pub async fn index(
         StatusCode::OK.into(),
         coaching_sessions,
     )))
+}
+
+/// GET a particular Note specified by its id.
+#[utoipa::path(
+    get,
+    path = "/notes/{id}",
+    params(
+        ApiVersion,
+        ("id" = String, Path, description = "Note id to retrieve")
+    ),
+    responses(
+        (status = 200, description = "Successfully retrieved a certain Note by its id", body = [entity::notes::Model]),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Note not found"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn read(
+    CompareApiVersion(_v): CompareApiVersion,
+    State(app_state): State<AppState>,
+    Path(id): Path<Id>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("GET Organization by id: {}", id);
+
+    let note: Option<notes::Model> =
+        NoteApi::find_by_id(app_state.db_conn_ref(), id).await?;
+
+    Ok(Json(ApiResponse::new(StatusCode::OK.into(), note)))
 }

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -127,7 +127,6 @@ pub async fn index(
     ),
     responses(
         (status = 200, description = "Successfully retrieved a certain Note by its id", body = [entity::notes::Model]),
-        (status = 204, description = "No content"),
         (status = 401, description = "Unauthorized"),
         (status = 404, description = "Note not found"),
         (status = 405, description = "Method not allowed")

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -145,8 +145,7 @@ pub async fn read(
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET Organization by id: {}", id);
 
-    let note: Option<notes::Model> =
-        NoteApi::find_by_id(app_state.db_conn_ref(), id).await?;
+    let note: Option<notes::Model> = NoteApi::find_by_id(app_state.db_conn_ref(), id).await?;
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), note)))
 }

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -39,7 +39,7 @@ impl IntoResponse for Error {
             EntityApiErrorCode::RecordNotFound => {
                 debug!("Error: {:#?}, mapping to NO_CONTENT", self);
 
-                (StatusCode::NO_CONTENT, "NO CONTENT").into_response()
+                (StatusCode::NOT_FOUND, "NOT FOUND").into_response()
             }
             EntityApiErrorCode::RecordNotUpdated => {
                 debug!("Error: {:#?}, mapping to UNPROCESSABLE_ENTITY", self);

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -29,6 +29,7 @@ use utoipa_rapidoc::RapiDoc;
             note_controller::create,
             note_controller::update,
             note_controller::index,
+            note_controller::read,
             organization_controller::index,
             organization_controller::read,
             organization_controller::create,
@@ -102,6 +103,7 @@ fn note_routes(app_state: AppState) -> Router {
         .route("/notes", post(note_controller::create))
         .route("/notes/:id", put(note_controller::update))
         .route("/notes", get(note_controller::index))
+        .route("/notes/:id", get(note_controller::read))
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)
 }


### PR DESCRIPTION
## Description
This PR adds the ability to retrieve a Note by its id.


#### GitHub Issue: None

### Changes
* Retrieve a Note by its id
* Make sure to return an error when an invalid id is specified

### Testing Strategy
1. Using [RAPIdoc](http://localhost:4000/rapidoc#get-/notes/-id-), try and retrieve an existing Note by its Id (look in the DB for an existing Note's id to test)
2. Observe that a 200 is returned with a Note JSON object 
3. Try entering a valid Id but of a Note that doesn't yet exist
4. Observe that a 204 is returned and No Content


### Concerns
None
