### PR TITLE
Make the status enum strings match the DB schema's strings

### DIFF
--- a/docs/db/refactor_platform_rs.dbml
+++ b/docs/db/refactor_platform_rs.dbml
@@ -89,6 +89,7 @@ Table refactor_platform.actions {
 }
 
 enum status {
+  not_started
   in_progress
   completed
   wont_do

--- a/entity/src/status.rs
+++ b/entity/src/status.rs
@@ -4,11 +4,13 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, Eq, PartialEq, EnumIter, Deserialize, Serialize, DeriveActiveEnum)]
 #[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "status")]
 pub enum Status {
-    #[sea_orm(string_value = "InProgress")]
+    #[sea_orm(string_value = "not_started")]
+    NotStarted,
+    #[sea_orm(string_value = "in_progress")]
     InProgress,
-    #[sea_orm(string_value = "Completed")]
+    #[sea_orm(string_value = "completed")]
     Completed,
-    #[sea_orm(string_value = "WontDo")]
+    #[sea_orm(string_value = "wont_do")]
     WontDo,
 }
 


### PR DESCRIPTION
## Description
Make the status enum strings match the DB schema's strings and add NotStarted as a new enum option.


#### GitHub Issue: None

### Changes
* Make the status enum strings match the DB schema's strings
* Add NotStarted as a new enum option

### Testing Strategy
N/A


### Concerns
None
