### PR TITLE
Delete agreement by its Id

### DIFF
--- a/entity_api/src/agreement.rs
+++ b/entity_api/src/agreement.rs
@@ -61,6 +61,26 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
     }
 }
 
+pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> {
+    let result = find_by_id(db, id).await?;
+
+    match result {
+        Some(agreement_model) => {
+            debug!(
+                "Existing Agreement model to be deleted: {:?}",
+                agreement_model
+            );
+
+            agreement_model.delete(db).await?;
+            Ok(())
+        }
+        None => Err(Error {
+            inner: None,
+            error_code: EntityApiErrorCode::RecordNotFound,
+        }),
+    }
+}
+
 pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>, Error> {
     match Entity::find_by_id(id).one(db).await {
         Ok(Some(agreement)) => {

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -133,10 +133,7 @@ fn agreement_routes(app_state: AppState) -> Router {
         .route("/agreements/:id", put(agreement_controller::update))
         .route("/agreements", get(agreement_controller::index))
         .route("/agreements/:id", get(agreement_controller::read))
-        .route(
-            "/agreements/:id",
-            delete(agreement_controller::delete),
-        )
+        .route("/agreements/:id", delete(agreement_controller::delete))
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -34,6 +34,7 @@ use utoipa_rapidoc::RapiDoc;
             agreement_controller::update,
             agreement_controller::index,
             agreement_controller::read,
+            agreement_controller::delete,
             note_controller::create,
             note_controller::update,
             note_controller::index,
@@ -132,6 +133,10 @@ fn agreement_routes(app_state: AppState) -> Router {
         .route("/agreements/:id", put(agreement_controller::update))
         .route("/agreements", get(agreement_controller::index))
         .route("/agreements/:id", get(agreement_controller::read))
+        .route(
+            "/agreements/:id",
+            delete(agreement_controller::delete),
+        )
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)
 }


### PR DESCRIPTION
## Description
This PR adds the ability to delete an existing Agreement specified by its Id.


#### GitHub Issue: None

### Changes
* Delete agreement by its Id

### Testing Strategy
1. Make sure to rerun the `scripts/rebuild_db.sh` script and re-seed the DB with `cargo run --bin seed_db`
2. Using the RAPIdoc web UI, try logging in, adding an Agreement and then deleting it


### Concerns
None
