### PR TITLE
Add endpoint to retrieve a CoachingRelationshipWithUserNames by relationship id

### DIFF
--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -97,7 +97,6 @@ pub async fn find_by_organization_with_user_names(
 
 pub async fn get_relationship_with_user_names(
     db: &DatabaseConnection,
-    _organization_id: Id,
     relationship_id: Id,
 ) -> Result<Option<CoachingRelationshipWithUserNames>, Error> {
     let coaches = Alias::new("coaches");
@@ -154,7 +153,6 @@ pub async fn find_by(
     Ok(query.all(db).await?)
 }
 
-//pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>, Error> {
 pub async fn by_coaching_relationship(
     query: Select<coaching_relationships::Entity>,
     id: Id,
@@ -166,29 +164,6 @@ pub async fn by_coaching_relationship(
         .into_query();
 
     query.filter(coaching_relationships::Column::Id.in_subquery(relationship_subsquery.to_owned()))
-
-    // match Entity::find_by_id(id).one(db).await {
-    //     Ok(Some(relationship)) => {
-    //         debug!("CoachingRelationship found: {:?}", relationship);
-
-    //         Ok(Some(relationship))
-    //     }
-    //     Ok(None) => {
-    //         error!("Relationship with id {} not found", id);
-
-    //         Err(Error {
-    //             inner: None,
-    //             error_code: EntityApiErrorCode::RecordNotFound,
-    //         })
-    //     }
-    //     Err(err) => {
-    //         error!("Relationship with id {} not found and returned error {}", id, err);
-    //         Err(Error {
-    //             inner: None,
-    //             error_code: EntityApiErrorCode::RecordNotFound,
-    //         })
-    //     }
-    // }
 }
 
 async fn by_organization(

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -3,7 +3,7 @@ use crate::uuid_parse_str;
 use chrono::Utc;
 use entity::{
     coachees, coaches,
-    coaching_relationships::{self, ActiveModel, Model},
+    coaching_relationships::{self, ActiveModel, Entity, Model},
     Id,
 };
 use sea_orm::{
@@ -95,6 +95,42 @@ pub async fn find_by_organization_with_user_names(
     Ok(query.all(db).await?)
 }
 
+pub async fn get_relationship_with_user_names(
+    db: &DatabaseConnection,
+    _organization_id: Id,
+    relationship_id: Id,
+) -> Result<Option<CoachingRelationshipWithUserNames>, Error> {
+    let coaches = Alias::new("coaches");
+    let coachees = Alias::new("coachees");
+
+    let query = by_coaching_relationship(coaching_relationships::Entity::find(), relationship_id)
+        .await
+        .join_as(
+            JoinType::Join,
+            coaches::Relation::CoachingRelationships.def().rev(),
+            coaches.clone(),
+        )
+        .join_as(
+            JoinType::Join,
+            coachees::Relation::CoachingRelationships.def().rev(),
+            coachees.clone(),
+        )
+        .select_only()
+        .column(coaching_relationships::Column::Id)
+        .column(coaching_relationships::Column::OrganizationId)
+        .column(coaching_relationships::Column::CoachId)
+        .column(coaching_relationships::Column::CoacheeId)
+        .column(coaching_relationships::Column::CreatedAt)
+        .column(coaching_relationships::Column::UpdatedAt)
+        .column_as(Expr::cust("coaches.first_name"), "coach_first_name")
+        .column_as(Expr::cust("coaches.last_name"), "coach_last_name")
+        .column_as(Expr::cust("coachees.first_name"), "coachee_first_name")
+        .column_as(Expr::cust("coachees.last_name"), "coachee_last_name")
+        .into_model::<CoachingRelationshipWithUserNames>();
+
+    Ok(query.one(db).await?)
+}
+
 pub async fn find_by(
     db: &DatabaseConnection,
     params: std::collections::HashMap<String, String>,
@@ -116,6 +152,43 @@ pub async fn find_by(
     }
 
     Ok(query.all(db).await?)
+}
+
+//pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>, Error> {
+pub async fn by_coaching_relationship(
+    query: Select<coaching_relationships::Entity>,
+    id: Id,
+) -> Select<coaching_relationships::Entity> {
+    let relationship_subsquery = Entity::find_by_id(id)
+        .select_only()
+        .column(entity::coaching_relationships::Column::Id)
+        .filter(entity::coaching_relationships::Column::Id.eq(id))
+        .into_query();
+
+    query.filter(coaching_relationships::Column::Id.in_subquery(relationship_subsquery.to_owned()))
+
+    // match Entity::find_by_id(id).one(db).await {
+    //     Ok(Some(relationship)) => {
+    //         debug!("CoachingRelationship found: {:?}", relationship);
+
+    //         Ok(Some(relationship))
+    //     }
+    //     Ok(None) => {
+    //         error!("Relationship with id {} not found", id);
+
+    //         Err(Error {
+    //             inner: None,
+    //             error_code: EntityApiErrorCode::RecordNotFound,
+    //         })
+    //     }
+    //     Err(err) => {
+    //         error!("Relationship with id {} not found and returned error {}", id, err);
+    //         Err(Error {
+    //             inner: None,
+    //             error_code: EntityApiErrorCode::RecordNotFound,
+    //         })
+    //     }
+    // }
 }
 
 async fn by_organization(

--- a/web/src/controller/organization/coaching_relationship_controller.rs
+++ b/web/src/controller/organization/coaching_relationship_controller.rs
@@ -38,14 +38,13 @@ pub async fn read(
     // TODO: create a new Extractor to authorize the user to access
     // the data requested
     State(app_state): State<AppState>,
-    Path((organization_id, relationship_id)): Path<(Id, Id)>,
+    Path((_organization_id, relationship_id)): Path<(Id, Id)>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET CoachingRelationship by id: {}", relationship_id);
 
     let relationship: Option<entity_api::coaching_relationship::CoachingRelationshipWithUserNames> =
         CoachingRelationshipApi::get_relationship_with_user_names(
             app_state.db_conn_ref(),
-            organization_id,
             relationship_id,
         )
         .await?;

--- a/web/src/controller/organization/coaching_relationship_controller.rs
+++ b/web/src/controller/organization/coaching_relationship_controller.rs
@@ -13,7 +13,47 @@ use service::config::ApiVersion;
 
 use log::*;
 
-/// GET a particular CoachingRelationship specified by its organization_id.
+/// GET a particular CoachingRelationship specified by the organization Id and relationship Id.
+#[utoipa::path(
+    get,
+    path = "/organizations/{organization_id}/coaching_relationships/{relationship_id}",
+    params(
+        ApiVersion,
+        ("organization_id" = Id, Path, description = "Organization id to retrieve the CoachingRelationship under"),
+        ("relationship_id" = String, Path, description = "CoachingRelationship id to retrieve")
+    ),
+    responses(
+        (status = 200, description = "Successfully retrieved a certain CoachingRelationship by its id", body = [entity::coaching_relationships::Model]),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "CoachingRelationship not found"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn read(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    // TODO: create a new Extractor to authorize the user to access
+    // the data requested
+    State(app_state): State<AppState>,
+    Path((organization_id, relationship_id)): Path<(Id, Id)>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("GET CoachingRelationship by id: {}", relationship_id);
+
+    let relationship: Option<entity_api::coaching_relationship::CoachingRelationshipWithUserNames> =
+        CoachingRelationshipApi::get_relationship_with_user_names(
+            app_state.db_conn_ref(),
+            organization_id,
+            relationship_id,
+        )
+        .await?;
+
+    Ok(Json(ApiResponse::new(StatusCode::OK.into(), relationship)))
+}
+
+/// GET all CoachingRelationships by organization_id
 #[utoipa::path(
     get,
     path = "/organizations/{organization_id}/coaching_relationships",
@@ -30,8 +70,6 @@ use log::*;
         ("cookie_auth" = [])
     )
 )]
-
-/// GET all CoachingRelationships by organization_id
 pub async fn index(
     CompareApiVersion(_v): CompareApiVersion,
     AuthenticatedUser(_user): AuthenticatedUser,
@@ -50,7 +88,7 @@ pub async fn index(
     debug!("Found CoachingRelationships: {:?}", coaching_relationships);
 
     Ok(Json(ApiResponse::new(
-        StatusCode::OK.as_u16(),
+        StatusCode::OK.into(),
         coaching_relationships,
     )))
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -54,6 +54,7 @@ use utoipa_rapidoc::RapiDoc;
             user_session_controller::login,
             user_session_controller::logout,
             organization::coaching_relationship_controller::index,
+            organization::coaching_relationship_controller::read,
             coaching_session_controller::index,
         ),
         components(
@@ -115,6 +116,10 @@ fn organization_coaching_relationship_routes(app_state: AppState) -> Router {
         .route(
             "/organizations/:organization_id/coaching_relationships",
             get(organization::coaching_relationship_controller::index),
+        )
+        .route(
+            "/organizations/:organization_id/coaching_relationships/:relationship_id",
+            get(organization::coaching_relationship_controller::read),
         )
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)


### PR DESCRIPTION
## Description
This PR adds an endpoint to retrieve a `CoachingRelationshipWithUserNames` by relationship id.


#### GitHub Issue: None

### Changes
* Add endpoint to retrieve a CoachingRelationshipWithUserNames by relationship id

### Testing Strategy
1. From the http://localhost:4000/rapidoc
2. Log in
3. Get a relationship id from the database
4. Navigate to the new endpoint in RAPIdoc and try and retrieve a `CoachingRelationshipWithUserNames` entity instance


### Concerns
None
