### PR TITLE
Return a richer user session JSON object

### DIFF
--- a/web/src/controller/user_session_controller.rs
+++ b/web/src/controller/user_session_controller.rs
@@ -62,9 +62,19 @@ pub async fn login(
         return Err(StatusCode::INTERNAL_SERVER_ERROR.into_response());
     }
 
+    let user_session_json = json!({
+            "id": user.id,
+            "email": user.email,
+            "first_name": user.first_name,
+            "last_name": user.last_name,
+            "display_name": user.display_name,
+    });
+
+    debug!("user_session_json: {}", user_session_json);
+
     Ok(Json(ApiResponse::new(
         StatusCode::OK.into(),
-        json!({"id": user.id}),
+        user_session_json,
     )))
 }
 


### PR DESCRIPTION
## Description
This PR returns a richer user session JSON object instead of only returning the user_id field.


#### GitHub Issue: None

### Changes
* Return a richer user session JSON object which includes email, first_name, last_name and display_name

### Testing Strategy
1. Log in with RAPIdoc
2. Notice that the returned JSON object includes these new fields


### Concerns
None
