### PR TITLE
Update seeded data

### DIFF
--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -79,8 +79,8 @@ pub async fn seed_database(db: &DatabaseConnection) {
     .await
     .unwrap();
 
-    let jim_hodapp_coaching = organizations::ActiveModel {
-        name: Set("Jim Hodapp's Coaching".to_owned()),
+    let refactor_coaching = organizations::ActiveModel {
+        name: Set("Refactor Coaching".to_owned()),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
         ..Default::default()
@@ -89,8 +89,8 @@ pub async fn seed_database(db: &DatabaseConnection) {
     .await
     .unwrap();
 
-    let jim_hodapp_other_org = organizations::ActiveModel {
-        name: Set("Jim Hodapp's Other Organization".to_owned()),
+    let acme_corp = organizations::ActiveModel {
+        name: Set("Acme Corp".to_owned()),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
         ..Default::default()
@@ -102,7 +102,7 @@ pub async fn seed_database(db: &DatabaseConnection) {
     let jim_caleb_coaching_relationship = coaching_relationships::ActiveModel {
         coach_id: Set(jim_hodapp.id.clone().unwrap()),
         coachee_id: Set(caleb_bourg.id.clone().unwrap()),
-        organization_id: Set(jim_hodapp_coaching.id.unwrap()),
+        organization_id: Set(refactor_coaching.id.unwrap()),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
         ..Default::default()
@@ -114,7 +114,7 @@ pub async fn seed_database(db: &DatabaseConnection) {
     coaching_relationships::ActiveModel {
         coach_id: Set(jim_hodapp.id.clone().unwrap()),
         coachee_id: Set(other_user.id.clone().unwrap()),
-        organization_id: Set(jim_hodapp_other_org.id.unwrap()),
+        organization_id: Set(acme_corp.id.unwrap()),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
         ..Default::default()
@@ -173,7 +173,7 @@ pub async fn seed_database(db: &DatabaseConnection) {
 
     coaching_sessions::ActiveModel {
         coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
-        date: Set(now.naive_local().checked_sub_days(Days::new(28)).unwrap()),
+        date: Set(now.naive_local().checked_add_days(Days::new(28)).unwrap()),
         timezone: Set("America/Chicago".to_owned()),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),

--- a/migration/src/refactor_platform_rs.sql
+++ b/migration/src/refactor_platform_rs.sql
@@ -1,6 +1,6 @@
--- SQL dump generated using DBML (dbml.dbdiagram.io)
+-- SQL dump generated using DBML (dbml-lang.org)
 -- Database: PostgreSQL
--- Generated at: 2024-10-10T11:19:54.853Z
+-- Generated at: 2024-10-31T16:04:10.825Z
 
 
 CREATE TYPE "status" AS ENUM (


### PR DESCRIPTION
## Description
This PR updates seeded data for the backend.


#### GitHub Issue: None

### Changes
* Updates the organization names to be more general
* Gets rid of the duplicate coaching session for the Jim Hodapp -> Caleb Bourg relationship

### Testing Strategy
1. Run `scripts/rebuild_db.sh`
2. Run `cargo run --bin seed_db`
3. Log into the frontend and observe "Refactor Coaching" and "Acme Corp" are the organization names
4. Also notice there are no longer duplicate coaching session dates in the dashboard session selector


### Concerns
None
